### PR TITLE
Coverage action should not run on macos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: lint
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
   pull_request:
@@ -13,15 +11,16 @@ permissions:
   pull-requests: read
 
 jobs:
-  golangci:
-    name: golangci
+  go:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+          # Required when using setup-go@v5, which enables caching by default.
+          # https://github.com/golangci/golangci-lint-action/issues/677
+          cache: false
+      - uses: golangci/golangci-lint-action@v4
         with:
           version: v1.57.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: coverage profile
-    strategy:
-      fail-fast: false
-      matrix:
-        go: [ '1.22' ]
-        os: [ ubuntu-latest, macos-latest, self-hosted-linux-arm64]
-    runs-on: ${{ matrix.os }}
+  simple:
+    # Tests will run on Ubuntu when we generate the coverage profile.
+    # The go-test-coverage action doesn't work on Mac.
+    runs-on: macos-latest
     steps:
         - uses: actions/checkout@v4
         - uses: actions/setup-go@v5
           with:
             go-version-file: go.mod
-        - name: generate test coverage
-          run: make install-go-test-coverage && make cover.out
-        - name: check test coverage
-          uses: vladopajic/go-test-coverage@v2
+        - run: make test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-go@v5
+          with:
+            go-version-file: go.mod
+        - run: make cover.out
+        - uses: vladopajic/go-test-coverage@v2
           with:
             config: .testcoverage.yml

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ install-go-test-coverage:
 
 $(COVER_OUT):
 	go test ./... -coverprofile=$@ -covermode=atomic -coverpkg=./...
+
+.PHONY: check-cover
+check-cover: $(COVER_OUT)
 	${GOBIN}/go-test-coverage --config=./.testcoverage.yml
 
 $(COVER_HTML): $(COVER_OUT)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated GitHub Actions workflows: Renamed a job for clarity, adjusted execution settings, and added a separate job for test coverage reports.
	- Updated Makefile: Added a new target for running test coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->