### PR TITLE
Add CometBFT RPC APIs

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -172,5 +172,6 @@ func (b *Builder) Build(payload *Payload) error {
 			return fmt.Errorf("publish event tx: %v", err)
 		}
 	}
+	// TODO publish other things like new blocks.
 	return nil
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	tmdb "github.com/cometbft/cometbft-db"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
 	bfttypes "github.com/cometbft/cometbft/types"
@@ -15,6 +14,7 @@ import (
 	"github.com/polymerdao/monomer/builder"
 	"github.com/polymerdao/monomer/genesis"
 	"github.com/polymerdao/monomer/mempool"
+	"github.com/polymerdao/monomer/testutil"
 	"github.com/polymerdao/monomer/testutil/testapp"
 	"github.com/stretchr/testify/require"
 )
@@ -78,26 +78,12 @@ func TestBuild(t *testing.T) {
 			inclusionListTxs := testapp.ToTxs(t, test.inclusionList)
 			mempoolTxs := testapp.ToTxs(t, test.mempool)
 
-			mempooldb := tmdb.NewMemDB()
-			t.Cleanup(func() {
-				require.NoError(t, mempooldb.Close())
-			})
-			pool := mempool.New(mempooldb)
+			pool := mempool.New(testutil.NewMemDB(t))
 			for _, tx := range mempoolTxs {
 				require.NoError(t, pool.Enqueue(tx))
 			}
-
-			blockdb := tmdb.NewMemDB()
-			t.Cleanup(func() {
-				require.NoError(t, blockdb.Close())
-			})
-			blockStore := store.NewBlockStore(blockdb)
-
-			txdb := tmdb.NewMemDB()
-			t.Cleanup(func() {
-				require.NoError(t, txdb.Close())
-			})
-			txStore := txstore.NewTxStore(txdb)
+			blockStore := store.NewBlockStore(testutil.NewMemDB(t))
+			txStore := txstore.NewTxStore(testutil.NewMemDB(t))
 
 			var chainID monomer.ChainID
 			app := testapp.NewTest(t, chainID.String())
@@ -199,23 +185,9 @@ func TestBuild(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	mempooldb := tmdb.NewMemDB()
-	t.Cleanup(func() {
-		require.NoError(t, mempooldb.Close())
-	})
-	pool := mempool.New(mempooldb)
-
-	blockdb := tmdb.NewMemDB()
-	t.Cleanup(func() {
-		require.NoError(t, blockdb.Close())
-	})
-	blockStore := store.NewBlockStore(blockdb)
-
-	txdb := tmdb.NewMemDB()
-	t.Cleanup(func() {
-		require.NoError(t, txdb.Close())
-	})
-	txStore := txstore.NewTxStore(txdb)
+	pool := mempool.New(testutil.NewMemDB(t))
+	blockStore := store.NewBlockStore(testutil.NewMemDB(t))
+	txStore := txstore.NewTxStore(testutil.NewMemDB(t))
 
 	var chainID monomer.ChainID
 	app := testapp.NewTest(t, chainID.String())

--- a/comet/comet.go
+++ b/comet/comet.go
@@ -1,0 +1,467 @@
+package comet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	bftbytes "github.com/cometbft/cometbft/libs/bytes"
+	bftpubsub "github.com/cometbft/cometbft/libs/pubsub"
+	bftquery "github.com/cometbft/cometbft/libs/pubsub/query"
+	"github.com/cometbft/cometbft/p2p"
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	jsonrpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
+	bfttypes "github.com/cometbft/cometbft/types"
+	"github.com/cometbft/cometbft/version"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/polymerdao/monomer"
+	"github.com/sourcegraph/conc"
+)
+
+var errProvingNotSupported = errors.New("proving is not supported")
+
+type AppABCI interface {
+	Info(abcitypes.RequestInfo) abcitypes.ResponseInfo
+	Query(abcitypes.RequestQuery) abcitypes.ResponseQuery
+}
+
+type ABCI struct {
+	app AppABCI
+}
+
+func NewABCI(app AppABCI) *ABCI {
+	return &ABCI{
+		app: app,
+	}
+}
+
+func (s *ABCI) Query(
+	_ *jsonrpctypes.Context,
+	path string,
+	data bftbytes.HexBytes,
+	height int64,
+	prove bool,
+) (*rpctypes.ResultABCIQuery, error) {
+	return &rpctypes.ResultABCIQuery{
+		Response: s.app.Query(abcitypes.RequestQuery{
+			Path:   path,
+			Data:   data,
+			Height: height,
+			Prove:  prove,
+		}),
+	}, nil
+}
+
+func (s *ABCI) Info(_ *jsonrpctypes.Context) (*rpctypes.ResultABCIInfo, error) {
+	return &rpctypes.ResultABCIInfo{
+		Response: s.app.Info(abcitypes.RequestInfo{}),
+	}, nil
+}
+
+type HeadBlocker interface {
+	HeadBlock() *monomer.Block
+}
+
+type Status struct {
+	blockstore HeadBlocker
+	startBlock *bfttypes.Block
+}
+
+func NewStatus(blockStore HeadBlocker, startBlock *bfttypes.Block) *Status {
+	return &Status{
+		blockstore: blockStore,
+		startBlock: startBlock,
+	}
+}
+
+// Status returns CometBFT status including node info, pubkey, latest block hash, app hash, block height, and block
+// time.
+// More: https://docs.cometbft.com/main/rpc/#/ABCI/status
+func (s *Status) Status(_ *jsonrpctypes.Context) (*rpctypes.ResultStatus, error) {
+	block := s.blockstore.HeadBlock()
+	if block == nil {
+		return nil, errors.New("head block not found")
+	}
+	headCometBlock := block.ToCometLikeBlock()
+	status := &rpctypes.ResultStatus{
+		NodeInfo: p2p.DefaultNodeInfo{
+			DefaultNodeID:   "",
+			ListenAddr:      "",
+			Network:         headCometBlock.ChainID,
+			Version:         version.TMCoreSemVer,
+			Channels:        []byte("0123456789"),
+			Moniker:         "monomer",
+			ProtocolVersion: p2p.NewProtocolVersion(version.P2PProtocol, version.BlockProtocol, 0),
+		},
+		// We need SyncInfo so the CosmJS tmClient doesn't complain.
+		SyncInfo: rpctypes.SyncInfo{
+			LatestBlockHash:   headCometBlock.Hash(),
+			LatestAppHash:     headCometBlock.AppHash,
+			LatestBlockHeight: headCometBlock.Height,
+			LatestBlockTime:   headCometBlock.Time,
+
+			EarliestBlockHash:   s.startBlock.Hash(),
+			EarliestAppHash:     s.startBlock.AppHash,
+			EarliestBlockHeight: s.startBlock.Height,
+			EarliestBlockTime:   s.startBlock.Time,
+
+			CatchingUp: false,
+		},
+		ValidatorInfo: rpctypes.ValidatorInfo{},
+	}
+	return status, nil
+}
+
+type AppMempool interface {
+	CheckTx(abcitypes.RequestCheckTx) abcitypes.ResponseCheckTx
+}
+
+type Mempool interface {
+	Enqueue(userTxn bfttypes.Tx) error
+}
+
+type BroadcastTx struct {
+	app     AppMempool
+	mempool Mempool
+}
+
+func NewBroadcastTx(app AppMempool, mempool Mempool) *BroadcastTx {
+	return &BroadcastTx{
+		app:     app,
+		mempool: mempool,
+	}
+}
+
+// BroadcastTxSync returns with the response from CheckTx, but does not wait for DeliverTx (tx execution).
+// More: https://docs.cometbft.com/main/rpc/#/Tx/broadcast_tx_sync
+func (s *BroadcastTx) BroadcastTx(_ *jsonrpctypes.Context, tx bfttypes.Tx) (*rpctypes.ResultBroadcastTx, error) {
+	checkTxResp := s.app.CheckTx(abcitypes.RequestCheckTx{
+		Tx:   tx,
+		Type: abcitypes.CheckTxType_New,
+	})
+	if err := s.mempool.Enqueue(tx); err != nil {
+		return nil, fmt.Errorf("enqueue in mempool: %v", err)
+	}
+	return &rpctypes.ResultBroadcastTx{
+		Code:      checkTxResp.GetCode(),
+		Log:       checkTxResp.GetLog(),
+		Codespace: checkTxResp.GetCodespace(),
+		Hash:      tx.Hash(),
+	}, nil
+}
+
+type EventBus interface {
+	Subscribe(ctx context.Context, subscriber string, query bftpubsub.Query, outCapacity ...int) (bfttypes.Subscription, error)
+	Unsubscribe(ctx context.Context, subscriber string, query bftpubsub.Query) error
+	UnsubscribeAll(ctx context.Context, subscriber string) error
+}
+
+type SubscribeEventListener interface {
+	// err will never be nil.
+	OnSubscriptionWriteErr(err error)
+	// err may be nil.
+	OnSubscriptionCanceled(err error)
+}
+
+type Subscriber struct {
+	eventBus      EventBus
+	wg            *conc.WaitGroup
+	eventListener SubscribeEventListener
+}
+
+func NewSubscriber(eventBus EventBus, wg *conc.WaitGroup, eventListener SubscribeEventListener) *Subscriber {
+	return &Subscriber{
+		eventBus:      eventBus,
+		wg:            wg,
+		eventListener: eventListener,
+	}
+}
+
+// Subscribe to events via websocket.
+func (s *Subscriber) Subscribe(ctx *jsonrpctypes.Context, query string) (*rpctypes.ResultSubscribe, error) {
+	parsedQuery, err := bftquery.New(query)
+	if err != nil {
+		return nil, fmt.Errorf("parse query: %w", err)
+	}
+
+	// From CometBFT:
+	//   The timeout is the maximum time we wait to subscribe for an event.
+	//   Must be less than the http server's write timeout.
+	subCtx, cancel := context.WithTimeout(ctx.Context(), 5*time.Second) //nolint:gomnd
+	defer cancel()
+
+	sub, err := s.eventBus.Subscribe(subCtx, ctx.RemoteAddr(), parsedQuery)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe to event bus: %w", err)
+	}
+
+	subscriptionID := ctx.JSONReq.ID
+
+	// push events to ws client
+	s.wg.Go(func() {
+		for {
+			select {
+			case msg := <-sub.Out():
+				resultEvent := &rpctypes.ResultEvent{
+					Query:  query,
+					Data:   msg.Data(),
+					Events: msg.Events(),
+				}
+				resp := jsonrpctypes.NewRPCSuccessResponse(subscriptionID, resultEvent)
+				writeCtx, cancel := context.WithTimeout(ctx.Context(), 10*time.Second) //nolint:gomnd
+				if writeErr := ctx.WSConn.WriteRPCResponse(writeCtx, resp); writeErr != nil {
+					cancel()
+					err := fmt.Errorf("subscription was canceled (reason: %v)", writeErr)
+					resp = jsonrpctypes.RPCServerError(subscriptionID, err)
+					ctx.WSConn.TryWriteRPCResponse(resp)
+					s.eventListener.OnSubscriptionWriteErr(err)
+					return
+				}
+				cancel()
+			case <-sub.Cancelled():
+				err = sub.Err()
+				if errors.Is(err, bftpubsub.ErrUnsubscribed) {
+					err = nil
+				} else {
+					var reason string
+					if err == nil {
+						reason = "Monomer exited"
+					} else {
+						reason = err.Error()
+					}
+					err = fmt.Errorf("subscription was canceled (reason: %s)", reason)
+					resp := jsonrpctypes.RPCServerError(subscriptionID, err)
+					ctx.WSConn.TryWriteRPCResponse(resp)
+				}
+				s.eventListener.OnSubscriptionCanceled(err)
+				return
+			}
+		}
+	})
+
+	return &rpctypes.ResultSubscribe{}, nil
+}
+
+// Unsubscribe from events via websocket.
+// More: https://docs.cometbft.com/main/rpc/#/ABCI/unsubscribe
+func (s *Subscriber) Unsubscribe(ctx *jsonrpctypes.Context, query string) (*rpctypes.ResultUnsubscribe, error) {
+	parsedQuery, err := bftquery.New(query)
+	if err != nil {
+		return nil, fmt.Errorf("parse query: %w", err)
+	}
+	if err := s.eventBus.Unsubscribe(ctx.Context(), ctx.RemoteAddr(), parsedQuery); err != nil {
+		return nil, fmt.Errorf("unsubscribe from event bus: %w", err)
+	}
+	return &rpctypes.ResultUnsubscribe{}, nil
+}
+
+// UnsubscribeAll unsubscribes from all events via websocket.
+// More: https://docs.cometbft.com/main/rpc/#/ABCI/unsubscribe_all
+func (s *Subscriber) UnsubscribeAll(ctx *jsonrpctypes.Context) (*rpctypes.ResultUnsubscribe, error) {
+	if err := s.eventBus.UnsubscribeAll(ctx.Context(), ctx.RemoteAddr()); err != nil {
+		return nil, fmt.Errorf("unsubscribe all: %v", err)
+	}
+	return &rpctypes.ResultUnsubscribe{}, nil
+}
+
+type TxStore interface {
+	Get(hash []byte) (*abcitypes.TxResult, error)
+	Search(ctx context.Context, q *bftquery.Query) ([]*abcitypes.TxResult, error)
+}
+
+type Tx struct {
+	txstore TxStore
+}
+
+func NewTx(txStore TxStore) *Tx {
+	return &Tx{
+		txstore: txStore,
+	}
+}
+
+// https://docs.cometbft.com/main/rpc/#/Tx/tx
+// NOTE: arg `hash` should be a hex string without 0x prefix
+func (s *Tx) ByHash(_ *jsonrpctypes.Context, hash []byte, prove bool) (*rpctypes.ResultTx, error) {
+	if prove {
+		return nil, errProvingNotSupported
+	}
+
+	r, err := s.txstore.Get(hash)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, fmt.Errorf("tx not found: %x", hash)
+	}
+	return &rpctypes.ResultTx{
+		Hash:     hash,
+		Height:   r.Height,
+		Index:    r.Index,
+		TxResult: r.Result,
+		Tx:       r.Tx,
+	}, nil
+}
+
+// TxSearch queries for multiple tx results. It returns a list of txs (max ?per_page_entries) and total count.
+// More: https://docs.cometbft.com/main/rpc/#/Tx/tx_search
+//
+// param pagePtr: 1-based page number, default (when pagePtr == nil) to 1
+// param perPagePtr: number of txs per page, default (when perPagePtr == nil) to 30
+// param orderBy: {"", "asc", "desc"}, default (when orderBy == "") to "asc"
+func (s *Tx) Search(
+	ctx *jsonrpctypes.Context,
+	query string,
+	prove bool,
+	pagePtr,
+	perPagePtr *int,
+	orderBy string,
+) (*rpctypes.ResultTxSearch, error) {
+	if prove {
+		return nil, errProvingNotSupported
+	}
+
+	q, err := bftquery.New(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	results, err := s.txstore.Search(ctx.Context(), q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search txs: %w", err)
+	}
+
+	// Sort results before pagination. Sort by height, then index.
+	switch orderBy {
+	case "desc":
+		sort.Slice(results, func(i, j int) bool {
+			if results[i].Height == results[j].Height {
+				return results[i].Index > results[j].Index
+			} else {
+				return results[i].Height > results[j].Height
+			}
+		})
+	case "asc", "": // Ascending order is the default.
+		sort.Slice(results, func(i, j int) bool {
+			if results[i].Height == results[j].Height {
+				return results[i].Index < results[j].Index
+			} else {
+				return results[i].Height < results[j].Height
+			}
+		})
+	default:
+		return nil, fmt.Errorf("expected order_by {asc, desc}, but got: '%s'", orderBy)
+	}
+
+	totalCount := len(results)
+	skipCount, returnedCount, err := paginate(pagePtr, perPagePtr, totalCount)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResults := make([]*rpctypes.ResultTx, 0, returnedCount)
+	for i := skipCount; i < skipCount+returnedCount; i++ {
+		r := results[i]
+		apiResults = append(apiResults, &rpctypes.ResultTx{
+			Hash:     bfttypes.Tx(r.Tx).Hash(),
+			Height:   r.Height,
+			Index:    r.Index,
+			TxResult: r.Result,
+			Tx:       r.Tx,
+		})
+	}
+
+	return &rpctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
+}
+
+// Paginate calculates the skip count and actual page size for pagination based on the given parameters.
+// It takes the page number, page size, and total count as inputs and returns the skip count, actual page size, and any error encountered.
+// If the page number or page size is invalid, an error is returned.
+// The default page size is used if the page size is not provided or is out of range.
+// The total number of pages is calculated based on the total count and page size.
+// The skip count is calculated as (page - 1) * page size.
+// The actual page size is calculated as the minimum of the page size and the remaining count after skipping (boundary check).
+func paginate(pagePtr, pageSizePtr *int, totalCount int) (int, int, error) {
+	var pageSize int
+	if pageSizePtr == nil || *pageSizePtr <= 0 || *pageSizePtr > 100 {
+		pageSize = 30
+	} else {
+		pageSize = *pageSizePtr
+	}
+
+	numPages := ((totalCount - 1) / pageSize) + 1
+
+	var pageNum int
+	if pagePtr == nil {
+		pageNum = 1
+	} else {
+		pageNum = *pagePtr
+	}
+
+	if pageNum <= 0 || pageNum > numPages {
+		return 0, 0, fmt.Errorf(
+			"page must be between 1 and %d, but got %d; totalCount: %d, pageSize: %d",
+			numPages,
+			pageNum,
+			totalCount,
+			pageSize,
+		)
+	}
+
+	// Calculate the skip count.
+	skipCount := (pageNum - 1) * pageSize
+	if skipCount < 0 {
+		skipCount = 0
+	}
+
+	// Calculate the actual page size
+	if count := totalCount - skipCount; count < pageSize {
+		pageSize = count
+	}
+
+	return skipCount, pageSize, nil
+}
+
+type BlockStore interface {
+	BlockByHash(common.Hash) *monomer.Block
+	BlockByNumber(int64) *monomer.Block
+}
+
+type Block struct {
+	blockstore BlockStore
+}
+
+func NewBlock(blockStore BlockStore) *Block {
+	return &Block{
+		blockstore: blockStore,
+	}
+}
+
+// https://docs.cometbft.com/main/rpc/#/ABCI/block
+func (s *Block) ByHeight(_ *jsonrpctypes.Context, height int64) (*rpctypes.ResultBlock, error) {
+	block := s.blockstore.BlockByNumber(height)
+	if block == nil {
+		return nil, fmt.Errorf("block not found: %d", height)
+	}
+	return rpcBlock(block.ToCometLikeBlock()), nil
+}
+
+// https://docs.cometbft.com/main/rpc/#/ABCI/block_by_hash
+func (s *Block) ByHash(_ *jsonrpctypes.Context, hash []byte) (*rpctypes.ResultBlock, error) {
+	block := s.blockstore.BlockByHash(common.BytesToHash(hash))
+	if block == nil {
+		return nil, fmt.Errorf("block not found: %x", hash)
+	}
+	return rpcBlock(block.ToCometLikeBlock()), nil
+}
+
+func rpcBlock(block *bfttypes.Block) *rpctypes.ResultBlock {
+	return &rpctypes.ResultBlock{
+		BlockID: bfttypes.BlockID{
+			Hash: block.Hash(),
+		},
+		Block: block,
+	}
+}

--- a/comet/comet_pkg_test.go
+++ b/comet/comet_pkg_test.go
@@ -1,0 +1,98 @@
+package comet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type paginateTest struct {
+	page,
+	requestedPageSize,
+	totalResults,
+	expectedSkip,
+	expectedPageSize int
+}
+
+func TestPaginateSuccess(t *testing.T) {
+	tests := map[string]paginateTest{
+		"no results": {
+			page:              1,
+			requestedPageSize: 10,
+			totalResults:      0,
+			expectedSkip:      0,
+			expectedPageSize:  0,
+		},
+		"one result": {
+			page:              1,
+			requestedPageSize: 10,
+			totalResults:      1,
+			expectedSkip:      0,
+			expectedPageSize:  1,
+		},
+		"exactly one page": {
+			page:              1,
+			requestedPageSize: 10,
+			totalResults:      10,
+			expectedSkip:      0,
+			expectedPageSize:  10,
+		},
+		"one  non-returned result": {
+			page:              1,
+			requestedPageSize: 10,
+			totalResults:      11,
+			expectedSkip:      0,
+			expectedPageSize:  10,
+		},
+		"return single second-page result": {
+			page:              2,
+			requestedPageSize: 10,
+			totalResults:      11,
+			expectedSkip:      10,
+			expectedPageSize:  1,
+		},
+		"return 10 second-page results": {
+			page:              2,
+			requestedPageSize: 10,
+			totalResults:      20,
+			expectedSkip:      10,
+			expectedPageSize:  10,
+		},
+		"return intermediate page": {
+			page:              16,
+			requestedPageSize: 10,
+			totalResults:      200,
+			expectedSkip:      150,
+			expectedPageSize:  10,
+		},
+	}
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
+			skip, pageSize, err := paginate(&test.page, &test.requestedPageSize, test.totalResults)
+			require.Equal(t, test.expectedSkip, skip)
+			require.Equal(t, test.expectedPageSize, pageSize)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPaginateFailure(t *testing.T) {
+	tests := map[string]paginateTest{
+		"pagenumber = 0": {
+			page:              0,
+			requestedPageSize: 10,
+			totalResults:      0,
+		},
+		"pagenumber < 0": {
+			page:              -1,
+			requestedPageSize: 10,
+			totalResults:      100,
+		},
+	}
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
+			_, _, err := paginate(&test.page, &test.requestedPageSize, test.totalResults)
+			require.Error(t, err)
+		})
+	}
+}

--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -1,0 +1,354 @@
+package comet_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/p2p"
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	jsonrpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
+	bfttypes "github.com/cometbft/cometbft/types"
+	"github.com/cometbft/cometbft/version"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/polymerdao/monomer"
+	"github.com/polymerdao/monomer/app/peptide/store"
+	"github.com/polymerdao/monomer/app/peptide/txstore"
+	"github.com/polymerdao/monomer/comet"
+	"github.com/polymerdao/monomer/mempool"
+	"github.com/polymerdao/monomer/testutil"
+	"github.com/polymerdao/monomer/testutil/testapp"
+	testappv1 "github.com/polymerdao/monomer/testutil/testapp/gen/testapp/v1"
+	"github.com/sourcegraph/conc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestABCI(t *testing.T) {
+	chainID := "0"
+	app := testapp.NewTest(t, chainID)
+	app.InitChain(abcitypes.RequestInitChain{
+		ChainId: chainID,
+		AppStateBytes: func() []byte {
+			appStateBytes, err := json.Marshal(testapp.MakeGenesisAppState(t, app))
+			require.NoError(t, err)
+			return appStateBytes
+		}(),
+	})
+
+	// data to store and retrieve
+	k := "k1"
+	v := "v1"
+
+	// Build bock with tx.
+	height := int64(1)
+	app.BeginBlock(abcitypes.RequestBeginBlock{
+		Header: *(&bfttypes.Header{
+			ChainID: chainID,
+			Height:  height,
+		}).ToProto(),
+	})
+	app.DeliverTx(abcitypes.RequestDeliverTx{
+		Tx: testapp.ToTx(t, k, v),
+	})
+	app.EndBlock(abcitypes.RequestEndBlock{})
+	app.Commit()
+
+	abci := comet.NewABCI(app)
+
+	// Info.
+	infoResult, err := abci.Info(nil)
+	require.NoError(t, err)
+	require.Equal(t, height, infoResult.Response.LastBlockHeight) // We trust that the other fields are set properly.
+	requestBytes, err := (&testappv1.GetRequest{
+		Key: k,
+	}).Marshal()
+	require.NoError(t, err)
+
+	// Query.
+	queryResult, err := abci.Query(nil, testapp.QueryPath, requestBytes, height, false)
+	require.NoError(t, err)
+	var val testappv1.GetResponse
+	require.NoError(t, (&val).Unmarshal(queryResult.Response.GetValue()))
+	require.Equal(t, v, val.GetValue())
+}
+
+func TestStatus(t *testing.T) {
+	blockStore := store.NewBlockStore(testutil.NewMemDB(t))
+	headBlock := &monomer.Block{
+		Header: &monomer.Header{},
+	}
+	blockStore.AddBlock(headBlock)
+	headCometBlock := headBlock.ToCometLikeBlock()
+	startBlock := &bfttypes.Block{
+		Header: bfttypes.Header{
+			AppHash: []byte{},
+			Height:  1,
+			Time:    time.Now(),
+		},
+	}
+	statusAPI := comet.NewStatus(blockStore, startBlock)
+	result, err := statusAPI.Status(nil)
+	require.NoError(t, err)
+	require.Equal(t, &rpctypes.ResultStatus{
+		NodeInfo: p2p.DefaultNodeInfo{
+			DefaultNodeID:   "",
+			ListenAddr:      "",
+			Network:         headCometBlock.ChainID,
+			Version:         version.TMCoreSemVer,
+			Channels:        []byte("0123456789"),
+			Moniker:         "monomer",
+			ProtocolVersion: p2p.NewProtocolVersion(version.P2PProtocol, version.BlockProtocol, 0),
+		},
+		// We need SyncInfo so the CosmJS tmClient doesn't complain.
+		SyncInfo: rpctypes.SyncInfo{
+			LatestBlockHash:   headCometBlock.Hash(),
+			LatestAppHash:     headCometBlock.AppHash,
+			LatestBlockHeight: headCometBlock.Height,
+			LatestBlockTime:   headCometBlock.Time,
+
+			EarliestBlockHash:   startBlock.Hash(),
+			EarliestAppHash:     startBlock.AppHash,
+			EarliestBlockHeight: startBlock.Height,
+			EarliestBlockTime:   startBlock.Time,
+
+			CatchingUp: false,
+		},
+		ValidatorInfo: rpctypes.ValidatorInfo{},
+	}, result)
+}
+
+func TestBroadcastTx(t *testing.T) {
+	chainID := "0"
+	app := testapp.NewTest(t, chainID)
+	mpool := mempool.New(testutil.NewMemDB(t))
+	broadcastAPI := comet.NewBroadcastTx(app, mpool)
+	tx := testapp.ToTx(t, "k1", "v1")
+	result, err := broadcastAPI.BroadcastTx(nil, tx)
+	require.NoError(t, err)
+	// We trust that the other fields are set correctly.
+	require.Equal(t, uint32(0), result.Code)
+	require.Equal(t, bfttypes.Tx(tx).Hash(), result.Hash.Bytes())
+	// NOTE: I don't think there is a way to check if CheckTx has been run.
+	// Both CheckTxType_New and CheckTxType_Recheck succeed.
+	got, err := mpool.Dequeue()
+	require.NoError(t, err)
+	require.Equal(t, bfttypes.Tx(tx), got)
+}
+
+type mockWSConnection struct {
+	ctx    context.Context
+	t      *testing.T
+	writes chan<- jsonrpctypes.RPCResponse
+}
+
+func newMockWSConnection(t *testing.T, writes chan<- jsonrpctypes.RPCResponse) *mockWSConnection {
+	return &mockWSConnection{
+		ctx:    context.Background(),
+		t:      t,
+		writes: writes,
+	}
+}
+
+func (c *mockWSConnection) GetRemoteAddr() string {
+	return "ws://127.0.0.1:8888/ws"
+}
+
+func (c *mockWSConnection) WriteRPCResponse(_ context.Context, resp jsonrpctypes.RPCResponse) error {
+	if c.writes != nil {
+		c.writes <- resp
+	}
+	return nil
+}
+
+func (c *mockWSConnection) TryWriteRPCResponse(resp jsonrpctypes.RPCResponse) bool {
+	// We know this is only called when writing an error string.
+	var errStr string
+	require.NoError(c.t, json.Unmarshal(resp.Result, &errStr))
+	require.Contains(c.t, errStr, "subscription was canceled (reason")
+	return true
+}
+
+func (c *mockWSConnection) Context() context.Context {
+	return c.ctx
+}
+
+func TestSubscribeUnsubscribe(t *testing.T) {
+	bus := bfttypes.NewEventBus()
+	require.NoError(t, bus.Start())
+	defer func() {
+		require.NoError(t, bus.Stop())
+	}()
+	wg := conc.NewWaitGroup()
+	defer wg.Wait()
+	subscribeAPI := comet.NewSubscriber(bus, wg, &comet.SelectiveListener{
+		OnSubscriptionWriteErrCb: func(err error) {
+			require.NoError(t, err)
+		},
+		OnSubscriptionCanceledCb: func(err error) {
+			require.NoError(t, err)
+		},
+	})
+
+	const height = 42
+	query := fmt.Sprintf("tx.height = %d", height)
+
+	// Subscribe, receive event, and unsubscribe.
+	writes := make(chan jsonrpctypes.RPCResponse)
+	defer close(writes)
+	wsConn := newMockWSConnection(t, writes)
+	result, err := subscribeAPI.Subscribe(&jsonrpctypes.Context{
+		JSONReq: &jsonrpctypes.RPCRequest{
+			JSONRPC: "2.0",
+			ID:      jsonrpctypes.JSONRPCIntID(1),
+			Method:  "subscribe",
+		},
+		WSConn: wsConn,
+	}, query)
+	require.NoError(t, err)
+	require.Equal(t, &rpctypes.ResultSubscribe{}, result)
+	event := bfttypes.EventDataTx{
+		TxResult: abcitypes.TxResult{
+			Height: height,
+		},
+	}
+	require.NoError(t, bus.PublishEventTx(event))
+	gotEvent := new(rpctypes.ResultEvent)
+	require.NoError(t, json.Unmarshal((<-writes).Result, &gotEvent))
+	gotHeight := func() int64 {
+		x1, ok := gotEvent.Data.(map[string]any)
+		require.True(t, ok)
+		x2, ok := x1["value"].(map[string]any)
+		require.True(t, ok)
+		x3, ok := x2["TxResult"].(map[string]any)
+		require.True(t, ok)
+		x4, ok := x3["height"].(string)
+		require.True(t, ok)
+		got, err := strconv.ParseInt(x4, 10, 64)
+		require.NoError(t, err)
+		return got
+	}()
+	require.Equal(t, event.GetHeight(), gotHeight)
+	resultUnsubscribe, err := subscribeAPI.Unsubscribe(&jsonrpctypes.Context{
+		JSONReq: &jsonrpctypes.RPCRequest{
+			JSONRPC: "2.0",
+			ID:      jsonrpctypes.JSONRPCIntID(0),
+			Method:  "unsubscribe",
+		},
+		WSConn: wsConn,
+	}, query)
+	require.NoError(t, err)
+	require.Equal(t, &rpctypes.ResultUnsubscribe{}, resultUnsubscribe)
+
+	// Subscribe multiple times and then unsubscribe via UnsubscribeAll.
+	wsConn = newMockWSConnection(t, nil)
+	_, err = subscribeAPI.Subscribe(&jsonrpctypes.Context{
+		JSONReq: &jsonrpctypes.RPCRequest{
+			JSONRPC: "2.0",
+			ID:      jsonrpctypes.JSONRPCIntID(1),
+			Method:  "subscribe",
+		},
+		WSConn: wsConn,
+	}, query)
+	require.NoError(t, err)
+	_, err = subscribeAPI.Subscribe(&jsonrpctypes.Context{
+		JSONReq: &jsonrpctypes.RPCRequest{
+			JSONRPC: "2.0",
+			ID:      jsonrpctypes.JSONRPCIntID(2),
+			Method:  "subscribe",
+		},
+		WSConn: wsConn,
+	}, "tx.index = 43")
+	require.NoError(t, err)
+	resultUnsubscribe, err = subscribeAPI.UnsubscribeAll(&jsonrpctypes.Context{
+		JSONReq: &jsonrpctypes.RPCRequest{
+			JSONRPC: "2.0",
+			ID:      jsonrpctypes.JSONRPCIntID(3),
+			Method:  "unsubscribe",
+		},
+		WSConn: wsConn,
+	})
+	require.NoError(t, err)
+	require.Equal(t, &rpctypes.ResultUnsubscribe{}, resultUnsubscribe)
+}
+
+func TestTx(t *testing.T) {
+	txStore := txstore.NewTxStore(testutil.NewMemDB(t))
+	txAPI := comet.NewTx(txStore)
+	_, err := txAPI.ByHash(nil, []byte{}, true)
+	require.ErrorContains(t, err, "proving is not supported")
+	wsConn := newMockWSConnection(t, nil)
+	_, err = txAPI.Search(&jsonrpctypes.Context{
+		WSConn: wsConn,
+	}, "tx.index = 1", true, nil, nil, "")
+	require.ErrorContains(t, err, "proving is not supported")
+
+	txResult1 := &abcitypes.TxResult{
+		Height: 2,
+		Index:  1,
+		Tx:     []byte{1, 2, 3},
+	}
+	txResult2 := &abcitypes.TxResult{
+		Height: txResult1.Height,
+		Index:  txResult1.Index + 1,
+		Tx:     []byte{4, 5, 6},
+	}
+	require.NoError(t, txStore.Add([]*abcitypes.TxResult{txResult1, txResult2}))
+
+	resultTx, err := txAPI.ByHash(nil, bfttypes.Tx(txResult1.GetTx()).Hash(), false)
+	require.NoError(t, err)
+	// We trust that the other fields are set properly.
+	require.Equal(t, txResult1.Height, resultTx.Height)
+	require.Equal(t, txResult1.Index, resultTx.Index)
+
+	// Ascending is the default, so the empty string also works.
+	for _, orderAscending := range []string{"asc", ""} {
+		searchResult, err := txAPI.Search(&jsonrpctypes.Context{
+			WSConn: newMockWSConnection(t, nil),
+		}, "tx.height = 2", false, nil, nil, orderAscending)
+		require.NoError(t, err)
+		require.Len(t, searchResult.Txs, 2)
+		require.Equal(t, txResult1.Tx, []byte(searchResult.Txs[0].Tx))
+		require.Equal(t, txResult2.Tx, []byte(searchResult.Txs[1].Tx))
+	}
+
+	searchResult, err := txAPI.Search(&jsonrpctypes.Context{
+		WSConn: wsConn,
+	}, "tx.height = 2", false, nil, nil, "desc")
+	require.NoError(t, err)
+	require.Len(t, searchResult.Txs, 2)
+	require.Equal(t, txResult2.Tx, []byte(searchResult.Txs[0].Tx))
+	require.Equal(t, txResult1.Tx, []byte(searchResult.Txs[1].Tx))
+}
+
+// TODO test pagination
+
+func TestBlock(t *testing.T) {
+	blockStore := store.NewBlockStore(testutil.NewMemDB(t))
+	block := &monomer.Block{
+		Header: &monomer.Header{
+			Height: 3,
+			Hash:   common.BytesToHash([]byte{1, 2, 3}),
+		},
+	}
+	cometBlock := block.ToCometLikeBlock()
+	want := &rpctypes.ResultBlock{
+		BlockID: bfttypes.BlockID{
+			Hash: cometBlock.Hash(),
+		},
+		Block: cometBlock,
+	}
+	blockStore.AddBlock(block)
+
+	blockAPI := comet.NewBlock(blockStore)
+	resultBlock, err := blockAPI.ByHeight(nil, block.Header.Height)
+	require.NoError(t, err)
+	require.Equal(t, want, resultBlock)
+
+	resultBlock, err = blockAPI.ByHash(nil, block.Hash().Bytes())
+	require.NoError(t, err)
+	require.Equal(t, want, resultBlock)
+}

--- a/comet/selective_listener.go
+++ b/comet/selective_listener.go
@@ -1,0 +1,18 @@
+package comet
+
+type SelectiveListener struct {
+	OnSubscriptionWriteErrCb func(error)
+	OnSubscriptionCanceledCb func(error)
+}
+
+func (s *SelectiveListener) OnSubscriptionWriteErr(err error) {
+	if s.OnSubscriptionWriteErrCb != nil {
+		s.OnSubscriptionWriteErrCb(err)
+	}
+}
+
+func (s *SelectiveListener) OnSubscriptionCanceled(err error) {
+	if s.OnSubscriptionCanceledCb != nil {
+		s.OnSubscriptionCanceledCb(err)
+	}
+}

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -49,10 +49,11 @@ func TestE2E(t *testing.T) {
 	require.NoError(t, err)
 
 	l1URL := newURL(t, "ws://127.0.0.1:8888")
-	monomerURL := newURL(t, "ws://127.0.0.1:8889")
-	opNodeURL := newURL(t, "http://127.0.0.1:8890")
+	monomerEngineURL := newURL(t, "ws://127.0.0.1:8889")
+	monomerCometURL := newURL(t, "http://127.0.0.1:8890")
+	opNodeURL := newURL(t, "http://127.0.0.1:8891")
 
-	stack := e2e.New(l1URL, monomerURL, opNodeURL, contractsRootDir, l1BlockTime, &e2e.SelectiveListener{
+	stack := e2e.New(l1URL, monomerEngineURL, monomerCometURL, opNodeURL, contractsRootDir, l1BlockTime, &e2e.SelectiveListener{
 		OPLogWithPrefixCb: func(prefix string, r *log.Record) {
 			if prefix != "node" && !verbose {
 				return
@@ -98,8 +99,8 @@ func TestE2E(t *testing.T) {
 	})
 	// To avoid flaky tests, hang until the Monomer server is ready.
 	// We rely on the `go test` timeout to ensure the tests don't hang forever (default is 10 minutes).
-	require.True(t, monomerURL.IsReachable(ctx))
-	monomerRPCClient, err := rpc.DialContext(ctx, monomerURL.String())
+	require.True(t, monomerEngineURL.IsReachable(ctx))
+	monomerRPCClient, err := rpc.DialContext(ctx, monomerEngineURL.String())
 	require.NoError(t, err)
 	monomerClient := e2e.NewMonomerClient(monomerRPCClient)
 

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -25,19 +25,19 @@ func (e *ChainID) ChainId() *hexutil.Big { //nolint:stylecheck
 	return e.chainID
 }
 
-type BlockByNumber struct {
+type Block struct {
 	blockStore store.BlockStoreReader
 	adapter    monomer.CosmosTxAdapter
 }
 
-func NewBlockByNumber(blockStore store.BlockStoreReader, adapter monomer.CosmosTxAdapter) *BlockByNumber {
-	return &BlockByNumber{
+func NewBlock(blockStore store.BlockStoreReader, adapter monomer.CosmosTxAdapter) *Block {
+	return &Block{
 		blockStore: blockStore,
 		adapter:    adapter,
 	}
 }
 
-func (e *BlockByNumber) GetBlockByNumber(id BlockID, inclTx bool) (map[string]any, error) {
+func (e *Block) GetBlockByNumber(id BlockID, inclTx bool) (map[string]any, error) {
 	b := id.Get(e.blockStore)
 	if b == nil {
 		return nil, ethereum.NotFound
@@ -49,19 +49,7 @@ func (e *BlockByNumber) GetBlockByNumber(id BlockID, inclTx bool) (map[string]an
 	return b.ToEthLikeBlock(txs, inclTx), nil
 }
 
-type BlockByHash struct {
-	blockStore store.BlockStoreReader
-	adapter    monomer.CosmosTxAdapter
-}
-
-func NewBlockByHash(blockStore store.BlockStoreReader, adapter monomer.CosmosTxAdapter) *BlockByHash {
-	return &BlockByHash{
-		blockStore: blockStore,
-		adapter:    adapter,
-	}
-}
-
-func (e *BlockByHash) GetBlockByHash(hash common.Hash, inclTx bool) (map[string]any, error) {
+func (e *Block) GetBlockByHash(hash common.Hash, inclTx bool) (map[string]any, error) {
 	block := e.blockStore.BlockByHash(hash)
 	if block == nil {
 		return nil, ethereum.NotFound

--- a/eth/eth_test.go
+++ b/eth/eth_test.go
@@ -77,7 +77,7 @@ func TestGetBlockByNumber(t *testing.T) {
 				"exclude txs": false,
 			} {
 				t.Run(description, func(t *testing.T) {
-					s := eth.NewBlockByNumber(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
+					s := eth.NewBlock(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
 					got, err := s.GetBlockByNumber(test.id, includeTxs)
 					if test.want == nil {
 						require.ErrorIs(t, err, ethereum.NotFound)
@@ -111,7 +111,7 @@ func TestGetBlockByHash(t *testing.T) {
 	} {
 		t.Run(description, func(t *testing.T) {
 			t.Run("block hash 1 exists", func(t *testing.T) {
-				e := eth.NewBlockByHash(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
+				e := eth.NewBlock(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
 				got, err := e.GetBlockByHash(block.Header.Hash, inclTx)
 				require.NoError(t, err)
 				require.Equal(t, block.ToEthLikeBlock(ethTxs(t, block.Txs), inclTx), got)
@@ -123,7 +123,7 @@ func TestGetBlockByHash(t *testing.T) {
 				"exclude txs": false,
 			} {
 				t.Run(description, func(t *testing.T) {
-					e := eth.NewBlockByHash(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
+					e := eth.NewBlock(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
 					got, err := e.GetBlockByHash(common.Hash{}, inclTx)
 					require.Nil(t, got)
 					require.ErrorIs(t, err, ethereum.NotFound)

--- a/monomer.go
+++ b/monomer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
+	bftbytes "github.com/cometbft/cometbft/libs/bytes"
 	bfttypes "github.com/cometbft/cometbft/types"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -141,6 +142,17 @@ func (b *Block) ToEthLikeBlock(txs ethtypes.Transactions, inclTxs bool) map[stri
 		result["transactions"] = txs
 	}
 	return result
+}
+
+func (b *Block) ToCometLikeBlock() *bfttypes.Block {
+	return &bfttypes.Block{
+		Header: bfttypes.Header{
+			ChainID: b.Header.ChainID.String(),
+			Time:    time.Unix(int64(b.Header.Time), 0),
+			Height:  b.Header.Height,
+			AppHash: bftbytes.HexBytes(b.Header.AppHash),
+		},
+	}
 }
 
 type PayloadAttributes struct {

--- a/node/node.go
+++ b/node/node.go
@@ -50,7 +50,10 @@ func New(
 
 func (n *Node) Run(parentCtx context.Context) (err error) {
 	ctx, cancel := context.WithCancelCause(parentCtx)
-	defer cancel(nil)
+	defer func() {
+		cancel(err)
+		err = utils.Cause(ctx)
+	}()
 
 	blockdb := tmdb.NewMemDB()
 	defer func() {
@@ -125,7 +128,7 @@ func (n *Node) Run(parentCtx context.Context) (err error) {
 	})
 
 	<-ctx.Done()
-	return utils.Cause(ctx)
+	return nil
 }
 
 func prepareBlockStoreAndApp(g *genesis.Genesis, blockStore store.BlockStore, app monomer.Application) error {

--- a/node/node.go
+++ b/node/node.go
@@ -4,15 +4,21 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 
 	tmdb "github.com/cometbft/cometbft-db"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/log"
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	cometserver "github.com/cometbft/cometbft/rpc/jsonrpc/server"
+	jsonrpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	bfttypes "github.com/cometbft/cometbft/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
 	"github.com/polymerdao/monomer/app/peptide/txstore"
 	"github.com/polymerdao/monomer/builder"
+	"github.com/polymerdao/monomer/comet"
 	"github.com/polymerdao/monomer/engine"
 	"github.com/polymerdao/monomer/eth"
 	"github.com/polymerdao/monomer/genesis"
@@ -24,8 +30,9 @@ import (
 type Node struct {
 	app                        monomer.Application
 	genesis                    *genesis.Genesis
-	httpListener               net.Listener
-	wsListener                 net.Listener
+	engineHTTP                 net.Listener
+	engineWS                   net.Listener
+	cometHTTPAndWS             net.Listener
 	adaptCosmosTxsToEthTxs     monomer.CosmosTxAdapter
 	adaptPayloadTxsToCosmosTxs monomer.PayloadTxAdapter
 }
@@ -33,18 +40,20 @@ type Node struct {
 func New(
 	app monomer.Application,
 	g *genesis.Genesis,
-	httpListener,
-	wsListener net.Listener,
+	engineHTTP net.Listener,
+	engineWS net.Listener,
+	cometHTTPAndWS net.Listener,
 	adaptCosmosTxsToEthTxs monomer.CosmosTxAdapter,
 	adaptPayloadTxsToCosmosTxs monomer.PayloadTxAdapter,
 ) *Node {
 	return &Node{
 		app:                        app,
 		genesis:                    g,
-		httpListener:               httpListener,
-		wsListener:                 wsListener,
-		adaptPayloadTxsToCosmosTxs: adaptPayloadTxsToCosmosTxs,
+		engineHTTP:                 engineHTTP,
+		engineWS:                   engineWS,
+		cometHTTPAndWS:             cometHTTPAndWS,
 		adaptCosmosTxsToEthTxs:     adaptCosmosTxsToEthTxs,
+		adaptPayloadTxsToCosmosTxs: adaptPayloadTxsToCosmosTxs,
 	}
 }
 
@@ -112,18 +121,66 @@ func (n *Node) Run(parentCtx context.Context) (err error) {
 		}
 	}
 
-	httpServer := makeHTTPService(rpcServer, n.httpListener)
+	httpServer := makeHTTPService(rpcServer, n.engineHTTP)
 	var wg conc.WaitGroup
 	wg.Go(func() {
 		if err := httpServer.Run(ctx); err != nil {
-			cancel(fmt.Errorf("start http server: %v", err))
+			cancel(fmt.Errorf("start engine http server: %v", err))
 		}
 	})
 
-	wsServer := makeHTTPService(rpcServer.WebsocketHandler([]string{}), n.wsListener)
+	wsServer := makeHTTPService(rpcServer.WebsocketHandler([]string{}), n.engineWS)
 	wg.Go(func() {
 		if err := wsServer.Run(ctx); err != nil {
-			cancel(fmt.Errorf("start websocket server: %v", err))
+			cancel(fmt.Errorf("start engine websocket server: %v", err))
+		}
+	})
+
+	// Run Comet server.
+
+	abci := comet.NewABCI(n.app)
+	broadcastAPI := comet.NewBroadcastTx(n.app, mpool)
+	txAPI := comet.NewTx(txStore)
+	subscribeWg := conc.NewWaitGroup()
+	defer subscribeWg.Wait()
+	subscribeAPI := comet.NewSubscriber(eventBus, subscribeWg, &comet.SelectiveListener{})
+	blockAPI := comet.NewBlock(blockStore)
+	// https://docs.cometbft.com/main/rpc/
+	routes := map[string]*cometserver.RPCFunc{
+		"echo": cometserver.NewRPCFunc(func(_ *jsonrpctypes.Context, msg string) (string, error) {
+			return msg, nil
+		}, "msg"),
+		"health": cometserver.NewRPCFunc(func(_ *jsonrpctypes.Context) (*rpctypes.ResultHealth, error) {
+			return &rpctypes.ResultHealth{}, nil
+		}, ""),
+		"status": cometserver.NewRPCFunc(comet.NewStatus(blockStore, nil).Status, ""), // TODO start block
+
+		"abci_query": cometserver.NewRPCFunc(abci.Query, "path,data,height,prove"),
+		"abci_info":  cometserver.NewRPCFunc(abci.Info, "", cometserver.Cacheable()),
+
+		"broadcast_tx_sync":  cometserver.NewRPCFunc(broadcastAPI.BroadcastTx, "tx"),
+		"broadcast_tx_async": cometserver.NewRPCFunc(broadcastAPI.BroadcastTx, "tx"),
+
+		"tx":        cometserver.NewRPCFunc(txAPI.ByHash, "hash,prove"),
+		"tx_search": cometserver.NewRPCFunc(txAPI.Search, "query,prove,page,per_page,order_by"),
+
+		"subscribe":       cometserver.NewRPCFunc(subscribeAPI.Subscribe, "query"),
+		"unsubscribe":     cometserver.NewRPCFunc(subscribeAPI.Unsubscribe, "query"),
+		"unsubscribe_all": cometserver.NewRPCFunc(subscribeAPI.UnsubscribeAll, ""),
+
+		"block":         cometserver.NewRPCFunc(blockAPI.ByHeight, "height"),
+		"block_by_hash": cometserver.NewRPCFunc(blockAPI.ByHash, "hash"),
+	}
+
+	mux := http.NewServeMux()
+	cometserver.RegisterRPCFuncs(mux, routes, log.NewNopLogger())
+	// We want to match cometbft's behavior, which puts the websocket endpoints under the /websocket route.
+	mux.HandleFunc("/websocket", cometserver.NewWebsocketManager(routes).WebsocketHandler)
+
+	cometServer := makeHTTPService(mux, n.cometHTTPAndWS)
+	wg.Go(func() {
+		if err := cometServer.Run(ctx); err != nil {
+			cancel(fmt.Errorf("start comet server: %v", err))
 		}
 	})
 

--- a/node/node.go
+++ b/node/node.go
@@ -97,12 +97,10 @@ func (n *Node) Run(parentCtx context.Context) (err error) {
 			Namespace: "eth",
 			Service: struct {
 				*eth.ChainID
-				*eth.BlockByNumber
-				*eth.BlockByHash
+				*eth.Block
 			}{
-				ChainID:       eth.NewChainID(n.genesis.ChainID.HexBig()),
-				BlockByNumber: eth.NewBlockByNumber(blockStore, n.adaptCosmosTxsToEthTxs),
-				BlockByHash:   eth.NewBlockByHash(blockStore, n.adaptCosmosTxsToEthTxs),
+				ChainID: eth.NewChainID(n.genesis.ChainID.HexBig()),
+				Block:   eth.NewBlock(blockStore, n.adaptCosmosTxsToEthTxs),
 			},
 		},
 	} {

--- a/testutil/testapp/helpers.go
+++ b/testutil/testapp/helpers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const QueryPath = "/testapp.v1.GetService/Get"
+
 func NewTest(t *testing.T, chainID string) *App {
 	appdb := tmdb.NewMemDB()
 	t.Cleanup(func() {
@@ -93,7 +95,7 @@ func (a *App) StateContains(t *testing.T, height uint64, kvs map[string]string) 
 		}).Marshal()
 		require.NoError(t, err)
 		resp := a.Query(abcitypes.RequestQuery{
-			Path:   "/testapp.v1.GetService/Get",
+			Path:   QueryPath,
 			Data:   requestBytes,
 			Height: int64(height),
 		})

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -1,0 +1,16 @@
+package testutil
+
+import (
+	"testing"
+
+	tmdb "github.com/cometbft/cometbft-db"
+	"github.com/stretchr/testify/require"
+)
+
+func NewMemDB(t *testing.T) tmdb.DB {
+	db := tmdb.NewMemDB()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced CometBFT functionality for handling ABCI queries, event subscription, and transaction and block retrieval.
	- Added new URL field configurations and listeners in the `Stack` struct for enhanced connectivity.
	- Integrated Comet server in the `Node` struct to handle various RPC functions.
	- Introduced `SelectiveListener` for improved subscription error handling.
	- Added a function to convert blocks to a Comet-like structure in the `Block` struct.

- **Bug Fixes**
	- Unified `BlockByNumber` and `BlockByHash` into a single `Block` type to simplify block retrieval operations.

- **Refactor**
	- Replaced `tmdb` with `testutil` for in-memory database creation in tests, enhancing test reliability and consistency.
	- Updated network listeners and introduced new dependencies for better HTTP and WebSocket handling in the `Node` struct.

- **Tests**
	- Enhanced test setups to reflect new configurations and component interactions, ensuring robustness.

- **Chores**
	- Added a new utility function for creating in-memory databases, facilitating easier test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->