### PR TITLE
Return all transactions with ExecutionPayloadEnvelope

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -85,8 +85,9 @@ func (b *Builder) Rollback(head, safe, finalized common.Hash) error {
 }
 
 type Payload struct {
-	// Transactions functions as an inclusion list.
-	Transactions bfttypes.Txs
+	// InjectedTransactions functions as an inclusion list. It contains transactions
+	// from the consensus layer that must be included in the block.
+	InjectedTransactions bfttypes.Txs
 	// TODO: make the gas limit actually be enforced. Need to translate between cosmos and op gas limit.
 	GasLimit  uint64
 	Timestamp uint64
@@ -94,7 +95,7 @@ type Payload struct {
 }
 
 func (b *Builder) Build(payload *Payload) error {
-	txs := slices.Clone(payload.Transactions) // Shallow clone is ok, we just don't want to modify the slice itself.
+	txs := slices.Clone(payload.InjectedTransactions) // Shallow clone is ok, we just don't want to modify the slice itself.
 	if !payload.NoTxPool {
 		for {
 			// TODO there is risk of losing txs if mempool db fails.

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -156,11 +156,13 @@ func (b *Builder) Build(payload *Payload) (*monomer.Block, error) {
 	})
 	b.app.Commit()
 
-	// Append block.
-	b.blockStore.AddBlock(&monomer.Block{
+	block := &monomer.Block{
 		Header: header,
 		Txs:    txs,
-	})
+	}
+
+	// Append block.
+	b.blockStore.AddBlock(block)
 	// Index txs.
 	if err := b.txStore.Add(txResults); err != nil {
 		return nil, fmt.Errorf("add tx results: %v", err)
@@ -173,5 +175,5 @@ func (b *Builder) Build(payload *Payload) (*monomer.Block, error) {
 			return nil, fmt.Errorf("publish event tx: %v", err)
 		}
 	}
-	return b.blockStore.HeadBlock(), nil
+	return block, nil
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -128,10 +128,10 @@ func TestBuild(t *testing.T) {
 			)
 
 			payload := &builder.Payload{
-				Transactions: bfttypes.ToTxs(inclusionListTxs),
-				GasLimit:     0,
-				Timestamp:    g.Time + 1,
-				NoTxPool:     test.noTxPool,
+				InjectedTransactions: bfttypes.ToTxs(inclusionListTxs),
+				GasLimit:             0,
+				Timestamp:            g.Time + 1,
+				NoTxPool:             test.noTxPool,
 			}
 			preBuildInfo := app.Info(abcitypes.RequestInfo{})
 			require.NoError(t, b.Build(payload))
@@ -246,8 +246,8 @@ func TestRollback(t *testing.T) {
 		"test": "test",
 	}
 	require.NoError(t, b.Build(&builder.Payload{
-		Timestamp:    g.Time + 1,
-		Transactions: bfttypes.ToTxs(testapp.ToTxs(t, kvs)),
+		Timestamp:            g.Time + 1,
+		InjectedTransactions: bfttypes.ToTxs(testapp.ToTxs(t, kvs)),
 	}))
 	block := blockStore.HeadBlock()
 	require.NotNil(t, block)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -134,7 +134,8 @@ func TestBuild(t *testing.T) {
 				NoTxPool:             test.noTxPool,
 			}
 			preBuildInfo := app.Info(abcitypes.RequestInfo{})
-			require.NoError(t, b.Build(payload))
+			_, err = b.Build(payload)
+			require.NoError(t, err)
 			postBuildInfo := app.Info(abcitypes.RequestInfo{})
 
 			// Application.
@@ -245,11 +246,11 @@ func TestRollback(t *testing.T) {
 	kvs := map[string]string{
 		"test": "test",
 	}
-	require.NoError(t, b.Build(&builder.Payload{
+	block, err := b.Build(&builder.Payload{
 		Timestamp:            g.Time + 1,
 		InjectedTransactions: bfttypes.ToTxs(testapp.ToTxs(t, kvs)),
-	}))
-	block := blockStore.HeadBlock()
+	})
+	require.NoError(t, err)
 	require.NotNil(t, block)
 	require.NoError(t, blockStore.UpdateLabel(eth.Unsafe, block.Hash()))
 	require.NoError(t, blockStore.UpdateLabel(eth.Safe, block.Hash()))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -237,7 +237,7 @@ func (e *EngineAPI) GetPayloadV3(payloadID engine.PayloadID) (*eth.ExecutionPayl
 
 	// TODO: handle time slot based block production
 	// for now assume block is sealed by this call
-	head, err := e.builder.Build(&builder.Payload{
+	block, err := e.builder.Build(&builder.Payload{
 		InjectedTransactions: e.currentPayloadAttributes.CosmosTxs,
 		GasLimit:             e.currentPayloadAttributes.GasLimit,
 		Timestamp:            e.currentPayloadAttributes.Timestamp,
@@ -247,7 +247,7 @@ func (e *EngineAPI) GetPayloadV3(payloadID engine.PayloadID) (*eth.ExecutionPayl
 		log.Panicf("failed to commit block: %v", err) // TODO error handling. An error here is potentially a big problem.
 	}
 
-	payloadEnvelope := e.currentPayloadAttributes.ToExecutionPayloadEnvelope(*head)
+	payloadEnvelope := e.currentPayloadAttributes.ToExecutionPayloadEnvelope(*block)
 
 	// remove payload
 	e.currentPayloadAttributes = nil

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -237,15 +237,17 @@ func (e *EngineAPI) GetPayloadV3(payloadID engine.PayloadID) (*eth.ExecutionPayl
 
 	// TODO: handle time slot based block production
 	// for now assume block is sealed by this call
-	if err := e.builder.Build(&builder.Payload{
+	head, err := e.builder.Build(&builder.Payload{
 		InjectedTransactions: e.currentPayloadAttributes.CosmosTxs,
 		GasLimit:             e.currentPayloadAttributes.GasLimit,
 		Timestamp:            e.currentPayloadAttributes.Timestamp,
 		NoTxPool:             e.currentPayloadAttributes.NoTxPool,
-	}); err != nil {
+	})
+	if err != nil {
 		log.Panicf("failed to commit block: %v", err) // TODO error handling. An error here is potentially a big problem.
 	}
-	payloadEnvelope := e.currentPayloadAttributes.ToExecutionPayloadEnvelope(e.blockStore.HeadBlock().Hash())
+
+	payloadEnvelope := e.currentPayloadAttributes.ToExecutionPayloadEnvelope(*head)
 
 	// remove payload
 	e.currentPayloadAttributes = nil

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -238,10 +238,10 @@ func (e *EngineAPI) GetPayloadV3(payloadID engine.PayloadID) (*eth.ExecutionPayl
 	// TODO: handle time slot based block production
 	// for now assume block is sealed by this call
 	if err := e.builder.Build(&builder.Payload{
-		Transactions: e.currentPayloadAttributes.CosmosTxs,
-		GasLimit:     e.currentPayloadAttributes.GasLimit,
-		Timestamp:    e.currentPayloadAttributes.Timestamp,
-		NoTxPool:     e.currentPayloadAttributes.NoTxPool,
+		InjectedTransactions: e.currentPayloadAttributes.CosmosTxs,
+		GasLimit:             e.currentPayloadAttributes.GasLimit,
+		Timestamp:            e.currentPayloadAttributes.Timestamp,
+		NoTxPool:             e.currentPayloadAttributes.NoTxPool,
 	}); err != nil {
 		log.Panicf("failed to commit block: %v", err) // TODO error handling. An error here is potentially a big problem.
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -247,7 +247,7 @@ func (e *EngineAPI) GetPayloadV3(payloadID engine.PayloadID) (*eth.ExecutionPayl
 		log.Panicf("failed to commit block: %v", err) // TODO error handling. An error here is potentially a big problem.
 	}
 
-	payloadEnvelope := e.currentPayloadAttributes.ToExecutionPayloadEnvelope(*block)
+	payloadEnvelope := e.currentPayloadAttributes.ToExecutionPayloadEnvelope(block)
 
 	// remove payload
 	e.currentPayloadAttributes = nil

--- a/monomer.go
+++ b/monomer.go
@@ -200,7 +200,7 @@ func hashDataAsBinary(h hash.Hash, data any) {
 	}
 }
 
-func (p *PayloadAttributes) ToExecutionPayloadEnvelope(block Block) *opeth.ExecutionPayloadEnvelope {
+func (p *PayloadAttributes) ToExecutionPayloadEnvelope(block *Block) *opeth.ExecutionPayloadEnvelope {
 	transactions := make([]hexutil.Bytes, len(block.Txs))
 
 	for i, tx := range block.Txs {

--- a/monomer.go
+++ b/monomer.go
@@ -200,17 +200,23 @@ func hashDataAsBinary(h hash.Hash, data any) {
 	}
 }
 
-func (p *PayloadAttributes) ToExecutionPayloadEnvelope(blockHash common.Hash) *opeth.ExecutionPayloadEnvelope {
+func (p *PayloadAttributes) ToExecutionPayloadEnvelope(block Block) *opeth.ExecutionPayloadEnvelope {
+	transactions := make([]hexutil.Bytes, len(block.Txs))
+
+	for i, tx := range block.Txs {
+		transactions[i] = hexutil.Bytes(tx)
+	}
+
 	return &opeth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &opeth.ExecutionPayload{
 			ParentHash:   p.ParentHash,
 			BlockNumber:  hexutil.Uint64(p.Height),
-			BlockHash:    blockHash,
+			BlockHash:    block.Hash(),
 			FeeRecipient: p.SuggestedFeeRecipient,
 			Timestamp:    hexutil.Uint64(p.Timestamp),
 			PrevRandao:   p.PrevRandao,
 			Withdrawals:  p.Withdrawals,
-			Transactions: p.Transactions,
+			Transactions: transactions,
 			GasLimit:     hexutil.Uint64(p.GasLimit),
 		},
 	}


### PR DESCRIPTION
PR addresses issue #17.

Previously, only the transactions that had arrived via the engineAPI's `forkChoiceUpdated()` `payloadAttributes` parameter were being reported back in the execution payload. Appchain transactions sourced from the mempool were dropped.

PR modifies `monomer.PayloadAttributes.ToExecutionPayloadEnvelope()` to receive an entire `monomer.Block`, rather than just the hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction handling by introducing `InjectedTransactions` for improved transaction injection and processing.

- **Bug Fixes**
  - Adjusted error handling in the building process to ensure better stability and clearer error messages.

- **Refactor**
  - Updated method signatures to return a block reference along with errors, facilitating better integration and error handling.
  - Modified payload struct and method parameters across multiple components to align with the new transaction handling approach.

- **Documentation**
  - Updated internal documentation to reflect changes in transaction processing and method outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->