### PR TITLE
Add back proto files

### DIFF
--- a/proto/rollup/genesis.proto
+++ b/proto/rollup/genesis.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package rollup;
+
+
+option go_package = "github.com/polymerdao/polymerase/chain/x/rollup/types";
+
+// GenesisState defines the polyibc module's genesis state.
+message GenesisState {
+}
+

--- a/proto/rollup/params.proto
+++ b/proto/rollup/params.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package rollup;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/polymerdao/polymerase/chain/x/rollup/types";
+
+// Params defines the parameters for the module.
+message Params {
+  option (gogoproto.goproto_stringer) = false;
+  // allowed_erc20_tokens defines the list of allowed client state types.
+  repeated string allowed_erc20_tokens = 1 [(gogoproto.moretags) = "yaml:\"allowed_erc20_tokens\""];
+}

--- a/proto/rollup/query.proto
+++ b/proto/rollup/query.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+package rollup;
+
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+
+option go_package = "github.com/polymerdao/polymerase/chain/x/rollup/types";
+
+// Query defines all tx endpoints for the rollup module.
+service Query {
+  rpc L1BlockInfo(QueryL1BlockInfoRequest) returns (QueryL1BlockInfoResponse) {
+    option (google.api.http).get = "/rollup/l1blockinfo/{height}";
+  }
+}
+
+// QueryL1BlockInfoRequest is the request type for the Query/L1BlockInfo RPC
+message QueryL1BlockInfoRequest {
+  option (gogoproto.goproto_getters) = false;
+  // L2 block height; use 0 for latest block height
+  uint64 height = 1;
+}
+
+// QueryL1BlockInfoResponse is the stored L1 block info
+message QueryL1BlockInfoResponse {
+  option (gogoproto.goproto_getters) = false;
+  // Block number
+  uint64 number = 1;
+  // Block timestamp
+  uint64 time = 2;
+  // Base fee for the block
+  bytes baseFee = 3;
+  // Hash of the blocK; bytes32
+  bytes blockHash = 4;
+  // Number of L2 blocks since the start of the epoch
+  // Not strictly a piece of L1 information. Represents the number of L2 blocks since the start of the epoch,
+  // i.e. when the actual L1 info was first introduced.
+  uint64 sequenceNumber = 5;
+  // Fields 6,7,8 are SystemConfig
+  // Address of the batcher; bytes20
+  bytes batcherAddr = 6;
+  // Overhead fee for L1; bytes32
+  bytes l1FeeOverhead = 7;
+  // Scalar fee for L1; bytes32
+  bytes l1FeeScalar = 8;
+}

--- a/proto/rollup/tx.proto
+++ b/proto/rollup/tx.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+package rollup;
+
+// import "gogoproto/gogo.proto";
+
+option go_package = "github.com/polymerdao/polymerase/chain/x/rollup/types";
+
+// Msg defines all tx endpoints for the rollup module.
+service Msg {
+  rpc ApplyL1Txs(MsgL1Txs) returns (MsgL1TxsResponse);
+}
+
+// MsgL1Txs defines a message for all L1 system and user deposit txs
+message MsgL1Txs {
+  // array of bytes, each bytes is a eth.Transaction.MarshalBinary tx
+  // The first tx must be a L1 system deposit tx, and the rest are user txs if present
+  repeated bytes txBytes = 1;
+}
+
+message MsgL1TxsResponse {
+}


### PR DESCRIPTION
Accidentally deleted a long time ago.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `GenesisState` configuration for initializing the module state.
  - Added parameters configuration for allowed ERC20 tokens.
  - Launched a new query service for fetching L1 block information.
  - Enabled new transaction functionalities for handling L1 system and user deposits.

- **Documentation**
  - Updated protocol buffer files to define new messages and services for the rollup module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->