### PR TITLE
Remove race condition in builder test

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -158,7 +158,6 @@ func TestBuild(t *testing.T) {
 
 			// Tx store and event bus.
 			eventChan := subscription.Out()
-			require.Len(t, eventChan, len(wantBlock.Txs))
 			for i, tx := range wantBlock.Txs {
 				checkTxResult := func(got abcitypes.TxResult) {
 					// We don't check the full result, which would be difficult and a bit overkill.


### PR DESCRIPTION
It was possible that the event bus subscription channel had not received all of the events by the time we were requiring it. Removing the check ensures we wait for the subscription channel to receive each event.

I'm not sure how we can ensure additional message aren't sent on the subscription. That is left untested, as before.