### PR TITLE
Add cosmos Tx consumption / rejection to e2e

### DIFF
--- a/comet/comet.go
+++ b/comet/comet.go
@@ -142,8 +142,10 @@ func (s *BroadcastTx) BroadcastTx(_ *jsonrpctypes.Context, tx bfttypes.Tx) (*rpc
 		Tx:   tx,
 		Type: abcitypes.CheckTxType_New,
 	})
-	if err := s.mempool.Enqueue(tx); err != nil {
-		return nil, fmt.Errorf("enqueue in mempool: %v", err)
+	if checkTxResp.Code == abcitypes.CodeTypeOK {
+		if err := s.mempool.Enqueue(tx); err != nil {
+			return nil, fmt.Errorf("enqueue in mempool: %v", err)
+		}
 	}
 	return &rpctypes.ResultBroadcastTx{
 		Code:      checkTxResp.GetCode(),

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -10,12 +10,16 @@ import (
 	"testing"
 	"time"
 
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	cosclient "github.com/cometbft/cometbft/rpc/client/http"
+	bfttypes "github.com/cometbft/cometbft/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/polymerdao/monomer/e2e"
 	e2eurl "github.com/polymerdao/monomer/e2e/url"
 	"github.com/polymerdao/monomer/environment"
 	"github.com/polymerdao/monomer/node"
+	"github.com/polymerdao/monomer/testutil/testapp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,6 +80,15 @@ func TestE2E(t *testing.T) {
 
 	const targetHeight = 5
 
+	client, err := cosclient.New(monomerCometURL.String(), monomerCometURL.String())
+	require.NoError(t, err, "failed to create Comet client")
+
+	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
+
+	put, err := client.BroadcastTxAsync(ctx, txBytes)
+	require.NoError(t, err)
+	require.Equal(t, abcitypes.CodeTypeOK, put.Code, "put.Code is not OK")
+
 	checkTicker := time.NewTicker(l1BlockTime)
 	defer checkTicker.Stop()
 	for range checkTicker.C {
@@ -87,11 +100,25 @@ func TestE2E(t *testing.T) {
 	}
 	t.Log("Monomer can sync")
 
+	bftTx := bfttypes.Tx(txBytes)
+	get, err := client.Tx(ctx, bftTx.Hash(), false)
+	txHeight := get.Height
+
+	require.NoError(t, err)
+	require.Equal(t, abcitypes.CodeTypeOK, get.TxResult.Code, "txResult.Code is not OK")
+	require.Equal(t, bftTx, get.Tx, "txBytes do not match")
+
+	txBlock, err := monomerClient.BlockByNumber(ctx, big.NewInt(get.Height))
+	require.NoError(t, err)
+	require.Len(t, txBlock.Transactions(), 2)
+
 	for i := uint64(2); i < targetHeight; i++ {
 		block, err := monomerClient.BlockByNumber(ctx, new(big.Int).SetUint64(i))
 		require.NoError(t, err)
 		txs := block.Transactions()
-		require.Len(t, txs, 1)
+		if i != uint64(txHeight) {
+			require.Len(t, txs, 1, "expected 1 tx in block")
+		}
 		if tx := txs[0]; !tx.IsDepositTx() {
 			txBytes, err := tx.MarshalJSON()
 			require.NoError(t, err)

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -84,10 +84,12 @@ func TestE2E(t *testing.T) {
 	require.NoError(t, err, "failed to create Comet client")
 
 	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
+	bftTx := bfttypes.Tx(txBytes)
 
 	put, err := client.BroadcastTxAsync(ctx, txBytes)
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, put.Code, "put.Code is not OK")
+	require.EqualValues(t, bftTx.Hash(), put.Hash, "put.Hash does not match local hash")
 
 	badTx := []byte("malformed")
 	badPut, err := client.BroadcastTxAsync(ctx, badTx)
@@ -105,7 +107,6 @@ func TestE2E(t *testing.T) {
 	}
 	t.Log("Monomer can sync")
 
-	bftTx := bfttypes.Tx(txBytes)
 	get, err := client.Tx(ctx, bftTx.Hash(), false)
 	txHeight := get.Height
 

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
-	cosclient "github.com/cometbft/cometbft/rpc/client/http"
+	bftclient "github.com/cometbft/cometbft/rpc/client/http"
 	bfttypes "github.com/cometbft/cometbft/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -80,7 +80,7 @@ func TestE2E(t *testing.T) {
 
 	const targetHeight = 5
 
-	client, err := cosclient.New(monomerCometURL.String(), monomerCometURL.String())
+	client, err := bftclient.New(monomerCometURL.String(), monomerCometURL.String())
 	require.NoError(t, err, "failed to create Comet client")
 
 	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -81,7 +81,7 @@ func TestE2E(t *testing.T) {
 	const targetHeight = 5
 
 	client, err := bftclient.New(monomerCometURL.String(), monomerCometURL.String())
-	require.NoError(t, err, "failed to create Comet client")
+	require.NoError(t, err, "create Comet client")
 
 	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
 	bftTx := bfttypes.Tx(txBytes)

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -89,6 +89,11 @@ func TestE2E(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, put.Code, "put.Code is not OK")
 
+	badTx := []byte("malformed")
+	badPut, err := client.BroadcastTxAsync(ctx, badTx)
+	require.NoError(t, err) // no API error - failure encoded in response
+	require.NotEqual(t, badPut.Code, abcitypes.CodeTypeOK, "badPut.Code is OK")
+
 	checkTicker := time.NewTicker(l1BlockTime)
 	defer checkTicker.Stop()
 	for range checkTicker.C {

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -86,13 +86,13 @@ func TestE2E(t *testing.T) {
 	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
 	bftTx := bfttypes.Tx(txBytes)
 
-	put, err := client.BroadcastTxAsync(ctx, txBytes)
+	putTx, err := client.BroadcastTxAsync(ctx, txBytes)
 	require.NoError(t, err)
-	require.Equal(t, abcitypes.CodeTypeOK, put.Code, "put.Code is not OK")
-	require.EqualValues(t, bftTx.Hash(), put.Hash, "put.Hash does not match local hash")
+	require.Equal(t, abcitypes.CodeTypeOK, putTx.Code, "put.Code is not OK")
+	require.EqualValues(t, bftTx.Hash(), putTx.Hash, "put.Hash does not match local hash")
 
-	badTx := []byte("malformed")
-	badPut, err := client.BroadcastTxAsync(ctx, badTx)
+	badPutTx := []byte("malformed")
+	badPut, err := client.BroadcastTxAsync(ctx, badPutTx)
 	require.NoError(t, err) // no API error - failure encoded in response
 	require.NotEqual(t, badPut.Code, abcitypes.CodeTypeOK, "badPut.Code is OK")
 
@@ -107,13 +107,13 @@ func TestE2E(t *testing.T) {
 	}
 	t.Log("Monomer can sync")
 
-	get, err := client.Tx(ctx, bftTx.Hash(), false)
+	getTx, err := client.Tx(ctx, bftTx.Hash(), false)
 
 	require.NoError(t, err)
-	require.Equal(t, abcitypes.CodeTypeOK, get.TxResult.Code, "txResult.Code is not OK")
-	require.Equal(t, bftTx, get.Tx, "txBytes do not match")
+	require.Equal(t, abcitypes.CodeTypeOK, getTx.TxResult.Code, "txResult.Code is not OK")
+	require.Equal(t, bftTx, getTx.Tx, "txBytes do not match")
 
-	txBlock, err := monomerClient.BlockByNumber(ctx, big.NewInt(get.Height))
+	txBlock, err := monomerClient.BlockByNumber(ctx, big.NewInt(getTx.Height))
 	require.NoError(t, err)
 	require.Len(t, txBlock.Transactions(), 2)
 

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -108,7 +108,6 @@ func TestE2E(t *testing.T) {
 	t.Log("Monomer can sync")
 
 	get, err := client.Tx(ctx, bftTx.Hash(), false)
-	txHeight := get.Height
 
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, get.TxResult.Code, "txResult.Code is not OK")
@@ -122,9 +121,7 @@ func TestE2E(t *testing.T) {
 		block, err := monomerClient.BlockByNumber(ctx, new(big.Int).SetUint64(i))
 		require.NoError(t, err)
 		txs := block.Transactions()
-		if i != uint64(txHeight) {
-			require.Len(t, txs, 1, "expected 1 tx in block")
-		}
+		require.GreaterOrEqual(t, len(txs), 1, "expected at least 1 tx in block")
 		if tx := txs[0]; !tx.IsDepositTx() {
 			txBytes, err := tx.MarshalJSON()
 			require.NoError(t, err)


### PR DESCRIPTION
PR
- submits a cosmos TX
- asserts that the Tx is retrievable
- attempts to submit a malformed Tx, asserts that the submission fails

Also: changes the RPC server to reject transactions that fail `CheckTx`, instead of feeding them to the mempool (where they're destined to be rejected later).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction handling to improve reliability in processing user transactions.

- **Bug Fixes**
	- Adjusted transaction enqueuing logic to ensure only valid transactions are processed, enhancing system stability.

- **Tests**
	- Expanded test coverage to include new scenarios for transaction broadcasting and result handling, ensuring robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->