### PR TITLE
Add a ProcessLogger helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.swp
 vendor/
+
+# Test artifacts
+e2e/artifacts/

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ $(COVER_HTML): $(COVER_OUT)
 clean:
 	if [ -f $(COVER_OUT) ]; then rm $(COVER_OUT); fi
 	if [ -f $(COVER_HTML) ]; then rm $(COVER_HTML); fi
-	if ls *.log 1> /dev/null 2>&1; then rm *.log; fi
+	find . -type f -name '*.log' -exec rm -f {} +

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -20,6 +20,7 @@ import (
 	"github.com/polymerdao/monomer/genesis"
 	"github.com/polymerdao/monomer/node"
 	"github.com/polymerdao/monomer/testapp"
+	"github.com/polymerdao/monomer/testutils"
 	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
@@ -75,6 +76,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) error {
 		"--gas-price", "0",
 		"--block-time", fmt.Sprint(s.l1BlockTime.Seconds()),
 	)
+	testutils.LogProcess("anvil", anvilCmd)
 	if err := anvilCmd.Start(); err != nil {
 		return fmt.Errorf("start %s: %v", anvilCmd, err)
 	}
@@ -114,6 +116,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) error {
 		"--broadcast",
 		"--private-key", common.Bytes2Hex(crypto.FromECDSA(privKey)),
 	)
+	testutils.LogProcess("forge", forgeCmd)
 	if err := forgeCmd.Start(); err != nil {
 		return fmt.Errorf("start %s: %v", forgeCmd, err)
 	}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -1,7 +1,13 @@
 package testutils
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	cometdb "github.com/cometbft/cometbft-db"
 	dbm "github.com/cosmos/cosmos-db"
@@ -22,4 +28,60 @@ func NewMemDB(t *testing.T) dbm.DB {
 		require.NoError(t, db.Close())
 	})
 	return db
+}
+
+// a timestamp helper
+func ts() string {
+	return time.Now().Format("[15:04:05.000] ")
+}
+
+// LogProcess captures the stdout and stderr of a process and writes it to
+// a file.
+func LogProcess(name string, cmd *exec.Cmd) error {
+
+	cmdOut, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("pipe stderr: %v", err)
+	}
+	cmdErr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("pipe stderr: %v", err)
+	}
+
+	outScanner := bufio.NewScanner(cmdOut)
+	errScanner := bufio.NewScanner(cmdErr)
+
+	now := time.Now().Format("01-02-15h04m05")
+	dest := fmt.Sprintf("./artifacts/%s_%s.log", name, now)
+
+	err = os.MkdirAll("./artifacts", 0755)
+	if err != nil {
+		return fmt.Errorf("create artifacts dir: %v", err)
+	}
+
+	destFile, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s out file: %v", name, err)
+	}
+
+	destWriter := io.Writer(destFile)
+
+	go func() {
+		for outScanner.Scan() {
+			line := ts() + outScanner.Text() + "\n"
+			if _, err := destWriter.Write([]byte(line)); err != nil {
+				panic(fmt.Errorf("writing to %s: %v", dest, err))
+			}
+		}
+	}()
+	go func() {
+		for errScanner.Scan() {
+			line := ts() + "[stderr] " + outScanner.Text() + "\n"
+			if _, err := destWriter.Write([]byte(line)); err != nil {
+				panic(fmt.Errorf("writing to %s: %v", dest, err))
+			}
+		}
+	}()
+
+	return nil
 }


### PR DESCRIPTION
PR adds a helper function to log & timestamp the outputs of e2e helper processes - `forge` and `anvil`. The produced outputs are supplementary to the existing logging in the e2e test.