### PR TITLE
Remove HTTP Handler for Engine API

### DIFF
--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -203,10 +203,6 @@ func (s *Stack) startCmd(cmd *exec.Cmd) error {
 }
 
 func (s *Stack) runMonomer(ctx context.Context, env *environment.Env, genesisTime, chainIDU64 uint64) error {
-	engineHTTP, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return fmt.Errorf("set up monomer engine http listener: %v", err)
-	}
 	engineWS, err := net.Listen("tcp", s.monomerEngineURL.Host())
 	if err != nil {
 		return fmt.Errorf("set up monomer engine ws listener: %v", err)
@@ -233,7 +229,6 @@ func (s *Stack) runMonomer(ctx context.Context, env *environment.Env, genesisTim
 			ChainID:  chainID,
 			Time:     genesisTime,
 		},
-		engineHTTP,
 		engineWS,
 		cometListener,
 		blockdb,

--- a/node/node.go
+++ b/node/node.go
@@ -37,7 +37,6 @@ type EventListener interface {
 type Node struct {
 	app                        monomer.Application
 	genesis                    *genesis.Genesis
-	engineHTTP                 net.Listener
 	engineWS                   net.Listener
 	cometHTTPAndWS             net.Listener
 	blockdb                    dbm.DB
@@ -51,7 +50,6 @@ type Node struct {
 func New(
 	app monomer.Application,
 	g *genesis.Genesis,
-	engineHTTP net.Listener,
 	engineWS net.Listener,
 	cometHTTPAndWS net.Listener,
 	blockdb,
@@ -64,7 +62,6 @@ func New(
 	return &Node{
 		app:                        app,
 		genesis:                    g,
-		engineHTTP:                 engineHTTP,
 		engineWS:                   engineWS,
 		cometHTTPAndWS:             cometHTTPAndWS,
 		blockdb:                    blockdb,
@@ -117,13 +114,6 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 			return fmt.Errorf("register %s API: %v", api.Namespace, err)
 		}
 	}
-
-	engineHTTP := makeHTTPService(rpcServer, n.engineHTTP)
-	env.Go(func() {
-		if err := engineHTTP.Run(ctx); err != nil {
-			n.eventListener.OnEngineHTTPServeErr(fmt.Errorf("run engine http server: %v", err))
-		}
-	})
 
 	engineWS := makeHTTPService(rpcServer.WebsocketHandler([]string{}), n.engineWS)
 	env.Go(func() {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -20,8 +20,6 @@ import (
 
 func TestRun(t *testing.T) {
 	chainID := monomer.ChainID(0)
-	engineHTTP, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
 	engineWS, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	cometListener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -45,7 +43,6 @@ func TestRun(t *testing.T) {
 			ChainID:  chainID,
 			AppState: testapp.MakeGenesisAppState(t, app),
 		},
-		engineHTTP,
 		engineWS,
 		cometListener,
 		blockdb,
@@ -70,7 +67,7 @@ func TestRun(t *testing.T) {
 	defer cancel()
 	require.NoError(t, n.Run(ctx, env))
 
-	client, err := rpc.DialContext(ctx, "http://"+engineHTTP.Addr().String())
+	client, err := rpc.DialContext(ctx, "ws://"+engineWS.Addr().String())
 	require.NoError(t, err)
 	defer client.Close()
 	ethClient := ethclient.NewClient(client)


### PR DESCRIPTION
This PR removes the HTTP handler for Engine API in `Node`. The OP stack just uses the websocket handler, so we don't need the HTTP listener.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal connection handling by removing the `engineHTTP` listener setup and usage.
  - Updated test configurations to use WebSocket (`engineWS`) instead of HTTP for client connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->