### PR TITLE
Inline tx adapters

### DIFF
--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -23,7 +23,6 @@ import (
 	"github.com/polymerdao/monomer/genesis"
 	"github.com/polymerdao/monomer/node"
 	"github.com/polymerdao/monomer/testapp"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
 const oneETH = uint64(1e18)
@@ -234,8 +233,6 @@ func (s *Stack) runMonomer(ctx context.Context, env *environment.Env, genesisTim
 		blockdb,
 		mempooldb,
 		txdb,
-		rolluptypes.AdaptCosmosTxsToEthTxs,
-		rolluptypes.AdaptPayloadTxsToCosmosTxs,
 		s.eventListener,
 	)
 	if err := n.Run(ctx, env); err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -15,7 +15,7 @@ import (
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
 	"github.com/polymerdao/monomer/builder"
-    rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
 type BlockStore interface {
@@ -42,9 +42,9 @@ func NewEngineAPI(
 	blockStore BlockStore,
 ) *EngineAPI {
 	return &EngineAPI{
-		txValidator:      txValidator,
-		blockStore:       blockStore,
-		builder:          b,
+		txValidator: txValidator,
+		blockStore:  blockStore,
+		builder:     b,
 	}
 }
 
@@ -254,7 +254,7 @@ func (e *EngineAPI) GetPayloadV3(ctx context.Context, payloadID engine.PayloadID
 		log.Panicf("failed to commit block: %v", err) // TODO error handling. An error here is potentially a big problem.
 	}
 
-    txs, err := rolluptypes.AdaptCosmosTxsToEthTxs(block.Txs)
+	txs, err := rolluptypes.AdaptCosmosTxsToEthTxs(block.Txs)
 	if err != nil {
 		return nil, engine.GenericServerError.With(fmt.Errorf("convert cosmos txs to eth txs: %v", err))
 	}

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/polymerdao/monomer/app/peptide/store"
-    rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
 // var errBlockNotFound = errors.New("block not found") // the op-node checks for this exact string.

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
+    rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
 // var errBlockNotFound = errors.New("block not found") // the op-node checks for this exact string.
@@ -27,13 +27,11 @@ func (e *ChainID) ChainId() *hexutil.Big { //nolint:stylecheck
 
 type Block struct {
 	blockStore store.BlockStoreReader
-	adapter    monomer.CosmosTxAdapter
 }
 
-func NewBlock(blockStore store.BlockStoreReader, adapter monomer.CosmosTxAdapter) *Block {
+func NewBlock(blockStore store.BlockStoreReader) *Block {
 	return &Block{
 		blockStore: blockStore,
-		adapter:    adapter,
 	}
 }
 
@@ -42,7 +40,7 @@ func (e *Block) GetBlockByNumber(id BlockID, inclTx bool) (map[string]any, error
 	if b == nil {
 		return nil, ethereum.NotFound
 	}
-	txs, err := e.adapter(b.Txs)
+	txs, err := rolluptypes.AdaptCosmosTxsToEthTxs(b.Txs)
 	if err != nil {
 		return nil, fmt.Errorf("adapt cosmos txs: %v", err)
 	}
@@ -54,7 +52,7 @@ func (e *Block) GetBlockByHash(hash common.Hash, inclTx bool) (map[string]any, e
 	if block == nil {
 		return nil, ethereum.NotFound
 	}
-	txs, err := e.adapter(block.Txs)
+	txs, err := rolluptypes.AdaptCosmosTxsToEthTxs(block.Txs)
 	if err != nil {
 		return nil, fmt.Errorf("adapt cosmos txs: %v", err)
 	}

--- a/eth/eth_test.go
+++ b/eth/eth_test.go
@@ -73,7 +73,7 @@ func TestGetBlockByNumber(t *testing.T) {
 				"exclude txs": false,
 			} {
 				t.Run(description, func(t *testing.T) {
-					s := eth.NewBlock(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
+					s := eth.NewBlock(blockStore)
 					got, err := s.GetBlockByNumber(test.id, includeTxs)
 					if test.want == nil {
 						require.ErrorIs(t, err, ethereum.NotFound)
@@ -103,7 +103,7 @@ func TestGetBlockByHash(t *testing.T) {
 	} {
 		t.Run(description, func(t *testing.T) {
 			t.Run("block hash 1 exists", func(t *testing.T) {
-				e := eth.NewBlock(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
+				e := eth.NewBlock(blockStore)
 				got, err := e.GetBlockByHash(block.Header.Hash, inclTx)
 				require.NoError(t, err)
 				require.Equal(t, block.ToEthLikeBlock(ethTxs(t, block.Txs), inclTx), got)
@@ -115,7 +115,7 @@ func TestGetBlockByHash(t *testing.T) {
 				"exclude txs": false,
 			} {
 				t.Run(description, func(t *testing.T) {
-					e := eth.NewBlock(blockStore, rolluptypes.AdaptCosmosTxsToEthTxs)
+					e := eth.NewBlock(blockStore)
 					got, err := e.GetBlockByHash(common.Hash{}, inclTx)
 					require.Nil(t, got)
 					require.ErrorIs(t, err, ethereum.NotFound)

--- a/monomer.go
+++ b/monomer.go
@@ -34,18 +34,6 @@ type Application interface {
 	RollbackToHeight(context.Context, uint64) error
 }
 
-// CosmosTxAdapter transforms Cosmos transactions into Ethereum transactions.
-//
-// In practice, this will use msg types from Monomer's rollup module, but importing the rollup module here would create a circular module
-// dependency between Monomer, the SDK, and the rollup module. sdk -> monomer -> rollup -> sdk, where -> is "depends on".
-type CosmosTxAdapter func(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, error)
-
-// PayloadTxAdapter transforms Op payload transactions into Cosmos transactions.
-//
-// In practice, this will use msg types from Monomer's rollup module, but importing the rollup module here would create a circular module
-// dependency between Monomer, the SDK, and the rollup module. sdk -> monomer -> rollup -> sdk, where -> is "depends on".
-type PayloadTxAdapter func(ethTxs []hexutil.Bytes) (bfttypes.Txs, error)
-
 type ChainID uint64
 
 func (id ChainID) String() string {

--- a/node/node.go
+++ b/node/node.go
@@ -35,14 +35,14 @@ type EventListener interface {
 }
 
 type Node struct {
-	app                        monomer.Application
-	genesis                    *genesis.Genesis
-	engineWS                   net.Listener
-	cometHTTPAndWS             net.Listener
-	blockdb                    dbm.DB
-	txdb                       cometdb.DB
-	mempooldb                  dbm.DB
-	eventListener              EventListener
+	app            monomer.Application
+	genesis        *genesis.Genesis
+	engineWS       net.Listener
+	cometHTTPAndWS net.Listener
+	blockdb        dbm.DB
+	txdb           cometdb.DB
+	mempooldb      dbm.DB
+	eventListener  EventListener
 }
 
 func New(
@@ -56,14 +56,14 @@ func New(
 	eventListener EventListener,
 ) *Node {
 	return &Node{
-		app:                        app,
-		genesis:                    g,
-		engineWS:                   engineWS,
-		cometHTTPAndWS:             cometHTTPAndWS,
-		blockdb:                    blockdb,
-		txdb:                       txdb,
-		mempooldb:                  mempooldb,
-		eventListener:              eventListener,
+		app:            app,
+		genesis:        g,
+		engineWS:       engineWS,
+		cometHTTPAndWS: cometHTTPAndWS,
+		blockdb:        blockdb,
+		txdb:           txdb,
+		mempooldb:      mempooldb,
+		eventListener:  eventListener,
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -42,8 +42,6 @@ type Node struct {
 	blockdb                    dbm.DB
 	txdb                       cometdb.DB
 	mempooldb                  dbm.DB
-	adaptCosmosTxsToEthTxs     monomer.CosmosTxAdapter
-	adaptPayloadTxsToCosmosTxs monomer.PayloadTxAdapter
 	eventListener              EventListener
 }
 
@@ -55,8 +53,6 @@ func New(
 	blockdb,
 	mempooldb dbm.DB,
 	txdb cometdb.DB,
-	adaptCosmosTxsToEthTxs monomer.CosmosTxAdapter,
-	adaptPayloadTxsToCosmosTxs monomer.PayloadTxAdapter,
 	eventListener EventListener,
 ) *Node {
 	return &Node{
@@ -67,8 +63,6 @@ func New(
 		blockdb:                    blockdb,
 		txdb:                       txdb,
 		mempooldb:                  mempooldb,
-		adaptCosmosTxsToEthTxs:     adaptCosmosTxsToEthTxs,
-		adaptPayloadTxsToCosmosTxs: adaptPayloadTxsToCosmosTxs,
 		eventListener:              eventListener,
 	}
 }
@@ -94,8 +88,6 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 			Service: engine.NewEngineAPI(
 				builder.New(mpool, n.app, blockStore, txStore, eventBus, n.genesis.ChainID),
 				n.app,
-				n.adaptPayloadTxsToCosmosTxs,
-				n.adaptCosmosTxsToEthTxs,
 				blockStore,
 			),
 		},

--- a/node/node.go
+++ b/node/node.go
@@ -106,7 +106,7 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 				*eth.Block
 			}{
 				ChainID: eth.NewChainID(n.genesis.ChainID.HexBig()),
-				Block:   eth.NewBlock(blockStore, n.adaptCosmosTxsToEthTxs),
+				Block:   eth.NewBlock(blockStore),
 			},
 		},
 	} {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/polymerdao/monomer/genesis"
 	"github.com/polymerdao/monomer/node"
 	"github.com/polymerdao/monomer/testapp"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,8 +47,6 @@ func TestRun(t *testing.T) {
 		blockdb,
 		mempooldb,
 		txdb,
-		rolluptypes.AdaptCosmosTxsToEthTxs,
-		rolluptypes.AdaptPayloadTxsToCosmosTxs,
 		&node.SelectiveListener{
 			OnEngineHTTPServeErrCb: func(err error) {
 				require.NoError(t, err)


### PR DESCRIPTION
This PR "inlines" the transaction adapters to and from Cosmos SDK and Ethereum types. Previously, they were being passed around as callbacks (we had needed this abstraction to avoid a dependency cycle, but that's no longer a concern). 

Essentially, we are removing the callbacks and instead calling the adapter implementations directly, for example, [`AdaptCosmosTxsToEthTxs`](https://github.com/polymerdao/monomer/blob/ec97025ded408a1ddd92619bccbec3bc0f9156a3/x/rollup/types/adapters.go#L62).

Requesting review: @joshklop @NiloCK 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified transaction adaptation by removing redundant adapter functions and fields across multiple components.
  - Updated function signatures and internal calls to use streamlined transaction adaptation methods.

- **Tests**
  - Simplified test functions by removing unnecessary parameters related to transaction adaptation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->