### PR TITLE
CI: upload e2e test artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,32 +10,36 @@ jobs:
   short:
     runs-on: macos-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: go.mod
-        - run: make test
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make test
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: go.mod
-        - run: make cover.out
-        - uses: vladopajic/go-test-coverage@v2
-          with:
-            config: .testcoverage.yml
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make cover.out
+      - uses: vladopajic/go-test-coverage@v2
+        with:
+          config: .testcoverage.yml
 
   e2e:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-          with:
-            submodules: 'recursive'
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: go.mod
-        - uses: foundry-rs/foundry-toolchain@v1
-        - run: make e2e
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: foundry-rs/foundry-toolchain@v1
+      - run: make e2e
+      - uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs
+          path: e2e/artifacts/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@v1
       - run: make e2e
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: e2e-logs
           path: e2e/artifacts/

--- a/e2e/op_stack.go
+++ b/e2e/op_stack.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/polymerdao/monomer/e2e/url"
@@ -95,6 +96,7 @@ func (op *OPStack) Run(ctx context.Context, env *environment.Env) error {
 		ReceiptQueryInterval:      defaults.ReceiptQueryInterval,
 		TxNotInMempoolTimeout:     defaults.TxNotInMempoolTimeout,
 		SafeAbortNonceTooLowCount: defaults.SafeAbortNonceTooLowCount,
+		From:                      crypto.PubkeyToAddress(op.privKey.PublicKey),
 		Signer: func(ctx context.Context, address common.Address, tx *ethtypes.Transaction) (*ethtypes.Transaction, error) {
 			return opcrypto.PrivateKeySignerFn(op.privKey, l1ChainID)(address, tx)
 		},


### PR DESCRIPTION
This PR is a replay of #37 with addition of a GH action to upload artifacts for the e2e test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Reformatted the test workflow for better readability and added an artifact upload step for end-to-end tests.

- **New Features**
  - Enhanced `OPStack` functionality by setting the `From` field using public key to address conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->