### PR TITLE
Upgrade go lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          # Required when using setup-go@v5, which enables caching by default.
-          # https://github.com/golangci/golangci-lint-action/issues/677
-          cache: false
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.57.2
   proto:


### PR DESCRIPTION
Caching was broken on the previous version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of `golangci/golangci-lint-action` to `v6` for improved linting performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->