### PR TITLE
Fix test condition for e2e-artifacts cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ $(COVER_HTML): $(COVER_OUT)
 clean:
 	if [ -f $(COVER_OUT) ]; then rm $(COVER_OUT); fi
 	if [ -f $(COVER_HTML) ]; then rm $(COVER_HTML); fi
-	if [ -f e2e/artifacts ]; then rm -r e2e/artifacts; fi
+	if [ -d e2e/artifacts ]; then rm -r e2e/artifacts; fi


### PR DESCRIPTION
Prior test had been looking specifically for a `file (-f)`, rather than a `directory (-d)`.

Other tests are correct - referring to files:

```
COVER_OUT ?= cover.out
COVER_HTML ?= cover.html
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal build processes to check for directories instead of files in the artifact cleaning step. This change improves robustness in project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->