### PR TITLE
Upload e2e artifacts on CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,32 +10,36 @@ jobs:
   short:
     runs-on: macos-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: go.mod
-        - run: make test
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make test
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: go.mod
-        - run: make cover.out
-        - uses: vladopajic/go-test-coverage@v2
-          with:
-            config: .testcoverage.yml
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make cover.out
+      - uses: vladopajic/go-test-coverage@v2
+        with:
+          config: .testcoverage.yml
 
   e2e:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-          with:
-            submodules: 'recursive'
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: go.mod
-        - uses: foundry-rs/foundry-toolchain@v1
-        - run: make e2e
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: foundry-rs/foundry-toolchain@v1
+      - run: make e2e
+      - uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs
+          path: e2e/artifacts/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@v1
       - run: make e2e
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: e2e-logs
           path: e2e/artifacts/


### PR DESCRIPTION
Separating this quality-of-life improvement from prior [stacked PR](https://github.com/polymerdao/monomer/pull/38).

PR adds an `upload-artifacts` action, making it easier to inspect failed e2e runs.

**Note:** uploaded artifacts have a fairly short lifespan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reformatted the indentation in the `.github/workflows/test.yml` file.
  - Added a step to upload artifacts in the `e2e` job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->