### PR TITLE
Rename RPC handlers to include "API" suffix

### DIFF
--- a/comet/comet.go
+++ b/comet/comet.go
@@ -131,13 +131,13 @@ type Mempool interface {
 	Enqueue(userTxn bfttypes.Tx) error
 }
 
-type BroadcastTx struct {
+type BroadcastAPI struct {
 	app     AppMempool
 	mempool Mempool
 }
 
-func NewBroadcastTx(app AppMempool, mempool Mempool) *BroadcastTx {
-	return &BroadcastTx{
+func NewBroadcastAPI(app AppMempool, mempool Mempool) *BroadcastAPI {
+	return &BroadcastAPI{
 		app:     app,
 		mempool: mempool,
 	}
@@ -145,7 +145,7 @@ func NewBroadcastTx(app AppMempool, mempool Mempool) *BroadcastTx {
 
 // BroadcastTxSync returns with the response from CheckTx, but does not wait for DeliverTx (tx execution).
 // More: https://docs.cometbft.com/main/rpc/#/Tx/broadcast_tx_sync
-func (s *BroadcastTx) BroadcastTx(ctx *jsonrpctypes.Context, tx bfttypes.Tx) (*rpctypes.ResultBroadcastTx, error) {
+func (s *BroadcastAPI) BroadcastTx(ctx *jsonrpctypes.Context, tx bfttypes.Tx) (*rpctypes.ResultBroadcastTx, error) {
 	checkTxResp, err := s.app.CheckTx(ctx.Context(), &abcitypes.RequestCheckTx{
 		Tx:   tx,
 		Type: abcitypes.CheckTxType_New,
@@ -179,14 +179,14 @@ type SubscribeEventListener interface {
 	OnSubscriptionCanceled(err error)
 }
 
-type Subscriber struct {
+type SubscriberAPI struct {
 	eventBus      EventBus
 	wg            *conc.WaitGroup
 	eventListener SubscribeEventListener
 }
 
-func NewSubscriber(eventBus EventBus, wg *conc.WaitGroup, eventListener SubscribeEventListener) *Subscriber {
-	return &Subscriber{
+func NewSubscriberAPI(eventBus EventBus, wg *conc.WaitGroup, eventListener SubscribeEventListener) *SubscriberAPI {
+	return &SubscriberAPI{
 		eventBus:      eventBus,
 		wg:            wg,
 		eventListener: eventListener,
@@ -194,7 +194,7 @@ func NewSubscriber(eventBus EventBus, wg *conc.WaitGroup, eventListener Subscrib
 }
 
 // Subscribe to events via websocket.
-func (s *Subscriber) Subscribe(ctx *jsonrpctypes.Context, query string) (*rpctypes.ResultSubscribe, error) {
+func (s *SubscriberAPI) Subscribe(ctx *jsonrpctypes.Context, query string) (*rpctypes.ResultSubscribe, error) {
 	parsedQuery, err := bftquery.New(query)
 	if err != nil {
 		return nil, fmt.Errorf("parse query: %w", err)
@@ -260,7 +260,7 @@ func (s *Subscriber) Subscribe(ctx *jsonrpctypes.Context, query string) (*rpctyp
 
 // Unsubscribe from events via websocket.
 // More: https://docs.cometbft.com/main/rpc/#/ABCI/unsubscribe
-func (s *Subscriber) Unsubscribe(ctx *jsonrpctypes.Context, query string) (*rpctypes.ResultUnsubscribe, error) {
+func (s *SubscriberAPI) Unsubscribe(ctx *jsonrpctypes.Context, query string) (*rpctypes.ResultUnsubscribe, error) {
 	parsedQuery, err := bftquery.New(query)
 	if err != nil {
 		return nil, fmt.Errorf("parse query: %w", err)
@@ -273,7 +273,7 @@ func (s *Subscriber) Unsubscribe(ctx *jsonrpctypes.Context, query string) (*rpct
 
 // UnsubscribeAll unsubscribes from all events via websocket.
 // More: https://docs.cometbft.com/main/rpc/#/ABCI/unsubscribe_all
-func (s *Subscriber) UnsubscribeAll(ctx *jsonrpctypes.Context) (*rpctypes.ResultUnsubscribe, error) {
+func (s *SubscriberAPI) UnsubscribeAll(ctx *jsonrpctypes.Context) (*rpctypes.ResultUnsubscribe, error) {
 	if err := s.eventBus.UnsubscribeAll(ctx.Context(), ctx.RemoteAddr()); err != nil {
 		return nil, fmt.Errorf("unsubscribe all: %v", err)
 	}
@@ -285,19 +285,19 @@ type TxStore interface {
 	Search(ctx context.Context, q *bftquery.Query) ([]*abcitypes.TxResult, error)
 }
 
-type Tx struct {
+type TxAPI struct {
 	txstore TxStore
 }
 
-func NewTx(txStore TxStore) *Tx {
-	return &Tx{
+func NewTxAPI(txStore TxStore) *TxAPI {
+	return &TxAPI{
 		txstore: txStore,
 	}
 }
 
 // https://docs.cometbft.com/main/rpc/#/Tx/tx
 // NOTE: arg `hash` should be a hex string without 0x prefix
-func (s *Tx) ByHash(_ *jsonrpctypes.Context, hash []byte, prove bool) (*rpctypes.ResultTx, error) {
+func (s *TxAPI) ByHash(_ *jsonrpctypes.Context, hash []byte, prove bool) (*rpctypes.ResultTx, error) {
 	if prove {
 		return nil, errProvingNotSupported
 	}
@@ -324,7 +324,7 @@ func (s *Tx) ByHash(_ *jsonrpctypes.Context, hash []byte, prove bool) (*rpctypes
 // param pagePtr: 1-based page number, default (when pagePtr == nil) to 1
 // param perPagePtr: number of txs per page, default (when perPagePtr == nil) to 30
 // param orderBy: {"", "asc", "desc"}, default (when orderBy == "") to "asc"
-func (s *Tx) Search(
+func (s *TxAPI) Search(
 	ctx *jsonrpctypes.Context,
 	query string,
 	prove bool,
@@ -442,18 +442,18 @@ type BlockStore interface {
 	BlockByNumber(int64) *monomer.Block
 }
 
-type Block struct {
+type BlockAPI struct {
 	blockstore BlockStore
 }
 
-func NewBlock(blockStore BlockStore) *Block {
-	return &Block{
+func NewBlockAPI(blockStore BlockStore) *BlockAPI {
+	return &BlockAPI{
 		blockstore: blockStore,
 	}
 }
 
 // https://docs.cometbft.com/main/rpc/#/ABCI/block
-func (s *Block) ByHeight(_ *jsonrpctypes.Context, height int64) (*rpctypes.ResultBlock, error) {
+func (s *BlockAPI) ByHeight(_ *jsonrpctypes.Context, height int64) (*rpctypes.ResultBlock, error) {
 	block := s.blockstore.BlockByNumber(height)
 	if block == nil {
 		return nil, fmt.Errorf("block not found: %d", height)
@@ -462,7 +462,7 @@ func (s *Block) ByHeight(_ *jsonrpctypes.Context, height int64) (*rpctypes.Resul
 }
 
 // https://docs.cometbft.com/main/rpc/#/ABCI/block_by_hash
-func (s *Block) ByHash(_ *jsonrpctypes.Context, hash []byte) (*rpctypes.ResultBlock, error) {
+func (s *BlockAPI) ByHash(_ *jsonrpctypes.Context, hash []byte) (*rpctypes.ResultBlock, error) {
 	block := s.blockstore.BlockByHash(common.BytesToHash(hash))
 	if block == nil {
 		return nil, fmt.Errorf("block not found: %x", hash)

--- a/comet/comet.go
+++ b/comet/comet.go
@@ -131,13 +131,13 @@ type Mempool interface {
 	Enqueue(userTxn bfttypes.Tx) error
 }
 
-type BroadcastAPI struct {
+type BroadcastTxAPI struct {
 	app     AppMempool
 	mempool Mempool
 }
 
-func NewBroadcastAPI(app AppMempool, mempool Mempool) *BroadcastAPI {
-	return &BroadcastAPI{
+func NewBroadcastTxAPI(app AppMempool, mempool Mempool) *BroadcastTxAPI {
+	return &BroadcastTxAPI{
 		app:     app,
 		mempool: mempool,
 	}
@@ -145,7 +145,7 @@ func NewBroadcastAPI(app AppMempool, mempool Mempool) *BroadcastAPI {
 
 // BroadcastTxSync returns with the response from CheckTx, but does not wait for DeliverTx (tx execution).
 // More: https://docs.cometbft.com/main/rpc/#/Tx/broadcast_tx_sync
-func (s *BroadcastAPI) BroadcastTx(ctx *jsonrpctypes.Context, tx bfttypes.Tx) (*rpctypes.ResultBroadcastTx, error) {
+func (s *BroadcastTxAPI) BroadcastTx(ctx *jsonrpctypes.Context, tx bfttypes.Tx) (*rpctypes.ResultBroadcastTx, error) {
 	checkTxResp, err := s.app.CheckTx(ctx.Context(), &abcitypes.RequestCheckTx{
 		Tx:   tx,
 		Type: abcitypes.CheckTxType_New,

--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -122,7 +122,7 @@ func TestBroadcastTx(t *testing.T) {
 	chainID := "0"
 	app := testapp.NewTest(t, chainID)
 	mpool := mempool.New(testutils.NewMemDB(t))
-	broadcastAPI := comet.NewBroadcastTx(app, mpool)
+	broadcastAPI := comet.NewBroadcastAPI(app, mpool)
 
 	// Succuss case.
 	tx := testapp.ToTx(t, "k1", "v1")
@@ -198,7 +198,7 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 	}()
 	wg := conc.NewWaitGroup()
 	defer wg.Wait()
-	subscribeAPI := comet.NewSubscriber(bus, wg, &comet.SelectiveListener{
+	subscribeAPI := comet.NewSubscriberAPI(bus, wg, &comet.SelectiveListener{
 		OnSubscriptionWriteErrCb: func(err error) {
 			require.NoError(t, err)
 		},
@@ -291,7 +291,7 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 
 func TestTx(t *testing.T) {
 	txStore := txstore.NewTxStore(testutils.NewCometMemDB(t))
-	txAPI := comet.NewTx(txStore)
+	txAPI := comet.NewTxAPI(txStore)
 	_, err := txAPI.ByHash(&jsonrpctypes.Context{}, []byte{}, true)
 	require.ErrorContains(t, err, "proving is not supported")
 	wsConn := newMockWSConnection(t, nil)
@@ -355,7 +355,7 @@ func TestBlock(t *testing.T) {
 	}
 	blockStore.AddBlock(block)
 
-	blockAPI := comet.NewBlock(blockStore)
+	blockAPI := comet.NewBlockAPI(blockStore)
 	resultBlock, err := blockAPI.ByHeight(&jsonrpctypes.Context{}, block.Header.Height)
 	require.NoError(t, err)
 	require.Equal(t, want, resultBlock)

--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -122,11 +122,11 @@ func TestBroadcastTx(t *testing.T) {
 	chainID := "0"
 	app := testapp.NewTest(t, chainID)
 	mpool := mempool.New(testutils.NewMemDB(t))
-	broadcastAPI := comet.NewBroadcastAPI(app, mpool)
+	broadcastTxAPI := comet.NewBroadcastTxAPI(app, mpool)
 
-	// Succuss case.
+	// Success case.
 	tx := testapp.ToTx(t, "k1", "v1")
-	result, err := broadcastAPI.BroadcastTx(&jsonrpctypes.Context{}, tx)
+	result, err := broadcastTxAPI.BroadcastTx(&jsonrpctypes.Context{}, tx)
 	require.NoError(t, err)
 	// We trust that the other fields are set correctly.
 	require.Equal(t, uint32(0), result.Code)
@@ -142,7 +142,7 @@ func TestBroadcastTx(t *testing.T) {
 	startLen, err := mpool.Len()
 	require.NoError(t, err)
 
-	result, err = broadcastAPI.BroadcastTx(&jsonrpctypes.Context{}, badTx)
+	result, err = broadcastTxAPI.BroadcastTx(&jsonrpctypes.Context{}, badTx)
 	// API does not error, but returns a non-zero error code.
 	require.NoError(t, err)
 	require.NotEqual(t, uint32(0), result.Code)

--- a/node/node.go
+++ b/node/node.go
@@ -117,12 +117,12 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 	// Run Comet server.
 
 	abci := comet.NewABCI(n.app)
-	broadcastAPI := comet.NewBroadcastTx(n.app, mpool)
-	txAPI := comet.NewTx(txStore)
+	broadcastAPI := comet.NewBroadcastAPI(n.app, mpool)
+	txAPI := comet.NewTxAPI(txStore)
 	subscribeWg := conc.NewWaitGroup()
 	env.Defer(subscribeWg.Wait)
-	subscribeAPI := comet.NewSubscriber(eventBus, subscribeWg, &comet.SelectiveListener{})
-	blockAPI := comet.NewBlock(blockStore)
+	subscribeAPI := comet.NewSubscriberAPI(eventBus, subscribeWg, &comet.SelectiveListener{})
+	blockAPI := comet.NewBlockAPI(blockStore)
 	// https://docs.cometbft.com/main/rpc/
 	routes := map[string]*cometserver.RPCFunc{
 		"echo": cometserver.NewRPCFunc(func(_ *jsonrpctypes.Context, msg string) (string, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -117,7 +117,7 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 	// Run Comet server.
 
 	abci := comet.NewABCI(n.app)
-	broadcastAPI := comet.NewBroadcastAPI(n.app, mpool)
+	broadcastTxAPI := comet.NewBroadcastTxAPI(n.app, mpool)
 	txAPI := comet.NewTxAPI(txStore)
 	subscribeWg := conc.NewWaitGroup()
 	env.Defer(subscribeWg.Wait)
@@ -136,8 +136,8 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 		"abci_query": cometserver.NewRPCFunc(abci.Query, "path,data,height,prove"),
 		"abci_info":  cometserver.NewRPCFunc(abci.Info, "", cometserver.Cacheable()),
 
-		"broadcast_tx_sync":  cometserver.NewRPCFunc(broadcastAPI.BroadcastTx, "tx"),
-		"broadcast_tx_async": cometserver.NewRPCFunc(broadcastAPI.BroadcastTx, "tx"),
+		"broadcast_tx_sync":  cometserver.NewRPCFunc(broadcastTxAPI.BroadcastTx, "tx"),
+		"broadcast_tx_async": cometserver.NewRPCFunc(broadcastTxAPI.BroadcastTx, "tx"),
 
 		"tx":        cometserver.NewRPCFunc(txAPI.ByHash, "hash,prove"),
 		"tx_search": cometserver.NewRPCFunc(txAPI.Search, "query,prove,page,per_page,order_by"),


### PR DESCRIPTION
Renames RPC handler structs and constructors to include the "API" suffix.
- `Tx` --> `TxAPI`
- `Block` --> `BlockAPI`
- `Subscriber`--> `SubscriberAPI`
- `BroadcastTx` --> `BroadcastTxAPI`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated API naming conventions for consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->