### PR TITLE
Add comet and mempool metrics

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -103,7 +103,7 @@ func (b *Builder) Build(ctx context.Context, payload *Payload) (*monomer.Block, 
 			// we need to fix db consistency in general, so we're just panicing on errors for now.
 			length, err := b.mempool.Len()
 			if err != nil {
-				panic(fmt.Errorf("enqueue: %v", err))
+				panic(fmt.Errorf("mempool length: %v", err))
 			}
 			if length == 0 {
 				break

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -78,7 +78,7 @@ func TestBuild(t *testing.T) {
 			inclusionListTxs := testapp.ToTxs(t, test.inclusionList)
 			mempoolTxs := testapp.ToTxs(t, test.mempool)
 
-			pool := mempool.New(testutils.NewMemDB(t))
+			pool := mempool.New(testutils.NewMemDB(t), mempool.NewNoopMetrics())
 			for _, tx := range mempoolTxs {
 				require.NoError(t, pool.Enqueue(tx))
 			}
@@ -194,7 +194,7 @@ func TestBuild(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	pool := mempool.New(testutils.NewMemDB(t))
+	pool := mempool.New(testutils.NewMemDB(t), mempool.NewNoopMetrics())
 	blockStore := store.NewBlockStore(testutils.NewMemDB(t))
 	txStore := txstore.NewTxStore(testutils.NewCometMemDB(t))
 

--- a/comet/metrics.go
+++ b/comet/metrics.go
@@ -1,0 +1,61 @@
+package comet
+
+import (
+	rpcmetrics "github.com/polymerdao/monomer/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const MetricsSubsystem = "comet"
+
+var RPCMethodDurationBucketsMicroseconds = []float64{1, 10, 50, 100, 500, 1000}
+
+// Metrics contains metrics collected from the engine package.
+type Metrics interface {
+	rpcmetrics.Metrics
+	RecordSubscribe(string)
+	RecordUnsubscribe(string)
+}
+
+type cometMetrics struct {
+	rpcmetrics.RPCMetrics
+	activeSubscriptions *prometheus.GaugeVec
+}
+
+func NewMetrics(namespace string) Metrics {
+	return &cometMetrics{
+		RPCMetrics: rpcmetrics.NewRPCMetrics(
+			namespace,
+			MetricsSubsystem,
+			"Duration of each comet API method call in microseconds",
+			RPCMethodDurationBucketsMicroseconds,
+		),
+		activeSubscriptions: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "active_subscriptions",
+			Help:      "Number of active comet subscriptions for a given query",
+		}, []string{
+			"query",
+		}),
+	}
+}
+
+func (m *cometMetrics) RecordSubscribe(query string) {
+	m.activeSubscriptions.WithLabelValues(query).Inc()
+}
+
+func (m *cometMetrics) RecordUnsubscribe(query string) {
+	m.activeSubscriptions.WithLabelValues(query).Dec()
+}
+
+type noopMetrics struct {
+	rpcmetrics.RPCNoopMetrics
+}
+
+func NewNoopMetrics() Metrics {
+	return &noopMetrics{}
+}
+
+func (m *noopMetrics) RecordSubscribe(_ string)   {}
+func (m *noopMetrics) RecordUnsubscribe(_ string) {}

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -66,12 +66,6 @@ func TestE2E(t *testing.T) {
 	prometheusCfg := &config.InstrumentationConfig{
 		Prometheus: false,
 	}
-	//prometheusCfg := &config.InstrumentationConfig{
-	//	Prometheus:           true,
-	//	PrometheusListenAddr: ":26660",
-	//	MaxOpenConnections:   1,
-	//	Namespace:            "monomer",
-	//}
 
 	stack := e2e.New(l1URL, monomerEngineURL, monomerCometURL, opNodeURL, deployConfigDir, l1StateDumpDir, l1BlockTime, prometheusCfg, &e2e.SelectiveListener{
 		OPLogCb: func(r slog.Record) {

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -66,6 +66,12 @@ func TestE2E(t *testing.T) {
 	prometheusCfg := &config.InstrumentationConfig{
 		Prometheus: false,
 	}
+	//prometheusCfg := &config.InstrumentationConfig{
+	//	Prometheus:           true,
+	//	PrometheusListenAddr: ":26660",
+	//	MaxOpenConnections:   1,
+	//	Namespace:            "monomer",
+	//}
 
 	stack := e2e.New(l1URL, monomerEngineURL, monomerCometURL, opNodeURL, deployConfigDir, l1StateDumpDir, l1BlockTime, prometheusCfg, &e2e.SelectiveListener{
 		OPLogCb: func(r slog.Record) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -77,7 +77,7 @@ func (e *EngineAPI) ForkchoiceUpdatedV3(
 ) (*eth.ForkchoiceUpdatedResult, error) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	defer e.metrics.RecordRPCMethodCall(ForkchoiceUpdatedV3MethodName, time.Now())
+	defer e.metrics.RecordMethodCall(ForkchoiceUpdatedV3MethodName, time.Now())
 
 	// OP spec:
 	//   - headBlockHash: block hash of the head of the canonical chain. Labeled "unsafe" in user JSON-RPC.
@@ -238,7 +238,7 @@ func (e *EngineAPI) GetPayloadV2(ctx context.Context, payloadID engine.PayloadID
 func (e *EngineAPI) GetPayloadV3(ctx context.Context, payloadID engine.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	e.lock.RLock()
 	defer e.lock.RUnlock()
-	defer e.metrics.RecordRPCMethodCall(GetPayloadV3MethodName, time.Now())
+	defer e.metrics.RecordMethodCall(GetPayloadV3MethodName, time.Now())
 
 	if e.currentPayloadAttributes == nil {
 		return nil, engine.InvalidParams.With(errors.New("payload not found"))
@@ -307,7 +307,7 @@ func (e *EngineAPI) NewPayloadV2(payload eth.ExecutionPayload) (*eth.PayloadStat
 func (e *EngineAPI) NewPayloadV3(payload eth.ExecutionPayload) (*eth.PayloadStatusV1, error) { //nolint:gocritic
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	defer e.metrics.RecordRPCMethodCall(NewPayloadV3MethodName, time.Now())
+	defer e.metrics.RecordMethodCall(NewPayloadV3MethodName, time.Now())
 
 	if e.blockStore.BlockByHash(payload.BlockHash) == nil {
 		return &eth.PayloadStatusV1{

--- a/engine/metrics.go
+++ b/engine/metrics.go
@@ -19,16 +19,16 @@ type Metrics interface {
 	rpcmetrics.Metrics
 }
 
-type metrics struct {
+type engineMetrics struct {
 	rpcmetrics.RPCMetrics
 }
 
 func NewMetrics(namespace string) Metrics {
-	return &metrics{
+	return &engineMetrics{
 		rpcmetrics.NewRPCMetrics(
 			namespace,
 			MetricsSubsystem,
-			"Duration of each engine RPC method call in microseconds",
+			"Duration of each engine API method call in microseconds",
 			RPCMethodDurationBucketsMicroseconds,
 		),
 	}

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -25,7 +25,7 @@ func NewChainID(chainID *hexutil.Big, metrics Metrics) *ChainID {
 }
 
 func (e *ChainID) ChainId() *hexutil.Big { //nolint:stylecheck
-	defer e.metrics.RecordRPCMethodCall(ChainIDMethodName, time.Now())
+	defer e.metrics.RecordMethodCall(ChainIDMethodName, time.Now())
 
 	return e.chainID
 }
@@ -43,7 +43,7 @@ func NewBlock(blockStore store.BlockStoreReader, metrics Metrics) *Block {
 }
 
 func (e *Block) GetBlockByNumber(id BlockID, inclTx bool) (map[string]any, error) {
-	defer e.metrics.RecordRPCMethodCall(GetBlockByNumberMethodName, time.Now())
+	defer e.metrics.RecordMethodCall(GetBlockByNumberMethodName, time.Now())
 
 	b := id.Get(e.blockStore)
 	if b == nil {
@@ -57,7 +57,7 @@ func (e *Block) GetBlockByNumber(id BlockID, inclTx bool) (map[string]any, error
 }
 
 func (e *Block) GetBlockByHash(hash common.Hash, inclTx bool) (map[string]any, error) {
-	defer e.metrics.RecordRPCMethodCall(GetBlockByHashMethodName, time.Now())
+	defer e.metrics.RecordMethodCall(GetBlockByHashMethodName, time.Now())
 
 	block := e.blockStore.BlockByHash(hash)
 	if block == nil {

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -19,12 +19,12 @@ type Metrics interface {
 	rpcmetrics.Metrics
 }
 
-type metrics struct {
+type ethMetrics struct {
 	rpcmetrics.RPCMetrics
 }
 
 func NewMetrics(namespace string) Metrics {
-	return &metrics{
+	return &ethMetrics{
 		rpcmetrics.NewRPCMetrics(
 			namespace,
 			MetricsSubsystem,

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMempool(t *testing.T) {
-	pool := mempool.New(testutils.NewMemDB(t))
+	pool := mempool.New(testutils.NewMemDB(t), mempool.NewNoopMetrics())
 
 	t.Run("empty pool", func(t *testing.T) {
 		l, err := pool.Len()

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -1,0 +1,46 @@
+package mempool
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const MetricsSubsystem = "mempool"
+
+type Metrics interface {
+	RecordEnqueueMempoolTx()
+	RecordDequeueMempoolTx()
+}
+
+type mempoolMetrics struct {
+	// Number of transactions in the mempool.
+	mempoolSize prometheus.Gauge
+}
+
+func NewMetrics(namespace string) Metrics {
+	return &mempoolMetrics{
+		mempoolSize: promauto.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "size",
+			Help:      "Number of transactions in the mempool",
+		}),
+	}
+}
+
+func (m *mempoolMetrics) RecordEnqueueMempoolTx() {
+	m.mempoolSize.Inc()
+}
+
+func (m *mempoolMetrics) RecordDequeueMempoolTx() {
+	m.mempoolSize.Dec()
+}
+
+type noopMetrics struct{}
+
+func NewNoopMetrics() Metrics {
+	return &noopMetrics{}
+}
+
+func (m *noopMetrics) RecordEnqueueMempoolTx() {}
+func (m *noopMetrics) RecordDequeueMempoolTx() {}

--- a/metrics/rpc_metrics.go
+++ b/metrics/rpc_metrics.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Metrics interface {
-	RecordRPCMethodCall(method string, start time.Time)
+	RecordMethodCall(method string, start time.Time)
 }
 
 type RPCMetrics struct {
@@ -30,11 +30,11 @@ func NewRPCMetrics(namespace, subsystem, info string, buckets []float64) RPCMetr
 	}
 }
 
-func (m *RPCMetrics) RecordRPCMethodCall(method string, start time.Time) {
+func (m *RPCMetrics) RecordMethodCall(method string, start time.Time) {
 	methodCallDuration := float64(time.Since(start).Microseconds())
 	m.MethodCalls.WithLabelValues(method).Observe(methodCallDuration)
 }
 
 type RPCNoopMetrics struct{}
 
-func (m *RPCNoopMetrics) RecordRPCMethodCall(_ string, _ time.Time) {}
+func (m *RPCNoopMetrics) RecordMethodCall(_ string, _ time.Time) {}

--- a/node/prometheus.go
+++ b/node/prometheus.go
@@ -3,14 +3,14 @@ package node
 import (
 	"context"
 	"fmt"
-	"github.com/polymerdao/monomer/comet"
-	"github.com/polymerdao/monomer/mempool"
 	"net"
 	"net/http"
 
+	"github.com/polymerdao/monomer/comet"
 	"github.com/polymerdao/monomer/engine"
 	"github.com/polymerdao/monomer/environment"
 	"github.com/polymerdao/monomer/eth"
+	"github.com/polymerdao/monomer/mempool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/node/prometheus.go
+++ b/node/prometheus.go
@@ -3,6 +3,8 @@ package node
 import (
 	"context"
 	"fmt"
+	"github.com/polymerdao/monomer/comet"
+	"github.com/polymerdao/monomer/mempool"
 	"net"
 	"net/http"
 
@@ -39,12 +41,16 @@ func (n *Node) startPrometheusServer(ctx context.Context, env *environment.Env) 
 	return nil
 }
 
-func (n *Node) registerMetrics() (eth.Metrics, engine.Metrics) {
+func (n *Node) registerMetrics() (eth.Metrics, engine.Metrics, comet.Metrics, mempool.Metrics) {
 	if n.prometheusCfg.IsPrometheusEnabled() {
 		namespace := n.prometheusCfg.Namespace
 		return eth.NewMetrics(namespace),
-			engine.NewMetrics(namespace)
+			engine.NewMetrics(namespace),
+			comet.NewMetrics(namespace),
+			mempool.NewMetrics(namespace)
 	}
 	return eth.NewNoopMetrics(),
-		engine.NewNoopMetrics()
+		engine.NewNoopMetrics(),
+		comet.NewNoopMetrics(),
+		mempool.NewNoopMetrics()
 }

--- a/testapp/helpers.go
+++ b/testapp/helpers.go
@@ -54,8 +54,8 @@ func ToTx(t *testing.T, k, v string) []byte {
 		// This is just a dummy address. The signature and gas checks are disabled in testapp.go,
 		// so this works for now.
 		FromAddress: "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh",
-		Key:   k,
-		Value: v,
+		Key:         k,
+		Value:       v,
 	})
 	require.NoError(t, err)
 	tx := &sdktx.Tx{

--- a/testapp/testapp_test.go
+++ b/testapp/testapp_test.go
@@ -1,8 +1,8 @@
 package testapp_test
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 

--- a/testapp/x/testmodule/module.go
+++ b/testapp/x/testmodule/module.go
@@ -57,7 +57,7 @@ type Module struct {
 }
 
 var (
-	_ module.AppModule  = (*Module)(nil)
+	_ module.AppModule      = (*Module)(nil)
 	_ module.HasABCIGenesis = (*Module)(nil)
 )
 


### PR DESCRIPTION
### Change Overview
- Adds basic metrics to track the count and duration of comet methods
- Adds subscriber metrics to track the number of active comet subscriptions for a given query
- Adds mempool metrics to track the number of transactions in the mempool

The changes in this PR use the prometheus server created in https://github.com/polymerdao/monomer/pull/58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for improved clarity in the build process.
	- Introduced metrics tracking for various APIs and the mempool.
	- New metrics system for monitoring API method calls and subscriptions.

- **Bug Fixes**
	- Updated instantiation of objects in tests to include metrics, aiding in test accuracy.

- **Documentation**
	- Improved readability and structure of code and comments for better understanding.

- **Refactor**
	- Unified metric recording methods across different components for consistency.
	- Renamed types and methods for better semantic clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->