### PR TITLE
Fix block hash bug

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,7 +113,7 @@ linters:
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    - path: _test\.go
+    - path: (testutils)|(_test\.go)
       linters:
         - gomnd
         - funlen
@@ -125,6 +125,7 @@ issues:
       source: "^//go:generate "
   exclude-dirs:
     - app # This code is left over and will be changed soon.
+    - eth/internal/ethapi
 
 run:
   timeout: 5m

--- a/eth/eth_test.go
+++ b/eth/eth_test.go
@@ -3,7 +3,6 @@ package eth_test
 import (
 	"testing"
 
-	bfttypes "github.com/cometbft/cometbft/types"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -11,8 +10,8 @@ import (
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
 	"github.com/polymerdao/monomer/eth"
+	"github.com/polymerdao/monomer/eth/internal/ethapi"
 	"github.com/polymerdao/monomer/testutils"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,23 +26,23 @@ func TestChainId(t *testing.T) {
 
 func TestGetBlockByNumber(t *testing.T) {
 	blockStore := store.NewBlockStore(testutils.NewMemDB(t))
-	block := &monomer.Block{
-		Header: &monomer.Header{
-			Hash: common.Hash{1},
-		},
-	}
+
+	block := testutils.GenerateBlock(t)
+	wantEthBlock, err := block.ToEth()
+	require.NoError(t, err)
+
 	blockStore.AddBlock(block)
 	require.NoError(t, blockStore.UpdateLabel(opeth.Unsafe, block.Header.Hash))
 
 	tests := map[string]struct {
 		id   eth.BlockID
-		want *monomer.Block
+		want *ethtypes.Block
 	}{
 		"unsafe block exists": {
 			id: eth.BlockID{
 				Label: opeth.Unsafe,
 			},
-			want: block,
+			want: wantEthBlock,
 		},
 		"safe block does not exist": {
 			id: eth.BlockID{
@@ -57,7 +56,7 @@ func TestGetBlockByNumber(t *testing.T) {
 		},
 		"block 0 exists": {
 			id:   eth.BlockID{},
-			want: block,
+			want: wantEthBlock,
 		},
 		"block 1 does not exist": {
 			id: eth.BlockID{
@@ -68,20 +67,22 @@ func TestGetBlockByNumber(t *testing.T) {
 
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
-			for description, includeTxs := range map[string]bool{
+			for description, fullTxs := range map[string]bool{
 				"include txs": true,
 				"exclude txs": false,
 			} {
 				t.Run(description, func(t *testing.T) {
 					s := eth.NewBlock(blockStore, eth.NewNoopMetrics())
-					got, err := s.GetBlockByNumber(test.id, includeTxs)
+					got, err := s.GetBlockByNumber(test.id, fullTxs)
 					if test.want == nil {
 						require.ErrorIs(t, err, ethereum.NotFound)
 						require.Nil(t, got)
 						return
 					}
 					require.NoError(t, err)
-					require.Equal(t, test.want.ToEthLikeBlock(ethTxs(t, block.Txs), includeTxs), got)
+					want, err := ethapi.SimpleRPCMarshalBlock(test.want, fullTxs)
+					require.NoError(t, err)
+					require.Equal(t, want, got)
 				})
 			}
 		})
@@ -90,23 +91,23 @@ func TestGetBlockByNumber(t *testing.T) {
 
 func TestGetBlockByHash(t *testing.T) {
 	blockStore := store.NewBlockStore(testutils.NewMemDB(t))
-	block := &monomer.Block{
-		Header: &monomer.Header{
-			Hash: common.Hash{1},
-		},
-	}
+	block := testutils.GenerateBlock(t)
 	blockStore.AddBlock(block)
 
-	for description, inclTx := range map[string]bool{
+	for description, fullTx := range map[string]bool{
 		"include txs": true,
 		"exclude txs": false,
 	} {
 		t.Run(description, func(t *testing.T) {
 			t.Run("block hash 1 exists", func(t *testing.T) {
 				e := eth.NewBlock(blockStore, eth.NewNoopMetrics())
-				got, err := e.GetBlockByHash(block.Header.Hash, inclTx)
+				got, err := e.GetBlockByHash(block.Header.Hash, fullTx)
 				require.NoError(t, err)
-				require.Equal(t, block.ToEthLikeBlock(ethTxs(t, block.Txs), inclTx), got)
+				ethBlock, err := block.ToEth()
+				require.NoError(t, err)
+				want, err := ethapi.SimpleRPCMarshalBlock(ethBlock, fullTx)
+				require.NoError(t, err)
+				require.Equal(t, want, got)
 			})
 		})
 		t.Run("block hash 0 does not exist", func(t *testing.T) {
@@ -123,10 +124,4 @@ func TestGetBlockByHash(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ethTxs(t *testing.T, cosmosTxs bfttypes.Txs) ethtypes.Transactions {
-	txs, err := rolluptypes.AdaptCosmosTxsToEthTxs(cosmosTxs)
-	require.NoError(t, err)
-	return txs
 }

--- a/eth/internal/ethapi/README.md
+++ b/eth/internal/ethapi/README.md
@@ -1,0 +1,3 @@
+Code in this package is copied from [op-geth](https://github.com/ethereum-optimism/op-geth/blob/optimism/internal/ethapi/api.go) at commit 3653ceb.
+
+The only semantic change is removing unused methods from the `Backend` interface and the addition of the code in the `helpers.go` file.

--- a/eth/internal/ethapi/api.go
+++ b/eth/internal/ethapi/api.go
@@ -1,0 +1,250 @@
+package ethapi
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
+type RPCTransaction struct {
+	BlockHash           *common.Hash      `json:"blockHash"`
+	BlockNumber         *hexutil.Big      `json:"blockNumber"`
+	From                common.Address    `json:"from"`
+	Gas                 hexutil.Uint64    `json:"gas"`
+	GasPrice            *hexutil.Big      `json:"gasPrice"`
+	GasFeeCap           *hexutil.Big      `json:"maxFeePerGas,omitempty"`
+	GasTipCap           *hexutil.Big      `json:"maxPriorityFeePerGas,omitempty"`
+	MaxFeePerBlobGas    *hexutil.Big      `json:"maxFeePerBlobGas,omitempty"`
+	Hash                common.Hash       `json:"hash"`
+	Input               hexutil.Bytes     `json:"input"`
+	Nonce               hexutil.Uint64    `json:"nonce"`
+	To                  *common.Address   `json:"to"`
+	TransactionIndex    *hexutil.Uint64   `json:"transactionIndex"`
+	Value               *hexutil.Big      `json:"value"`
+	Type                hexutil.Uint64    `json:"type"`
+	Accesses            *types.AccessList `json:"accessList,omitempty"`
+	ChainID             *hexutil.Big      `json:"chainId,omitempty"`
+	BlobVersionedHashes []common.Hash     `json:"blobVersionedHashes,omitempty"`
+	V                   *hexutil.Big      `json:"v"`
+	R                   *hexutil.Big      `json:"r"`
+	S                   *hexutil.Big      `json:"s"`
+	YParity             *hexutil.Uint64   `json:"yParity,omitempty"`
+
+	// deposit-tx only
+	SourceHash *common.Hash `json:"sourceHash,omitempty"`
+	Mint       *hexutil.Big `json:"mint,omitempty"`
+	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
+	// deposit-tx post-Canyon only
+	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
+}
+
+// RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
+// returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
+// transaction hashes.
+func RPCMarshalBlock(ctx context.Context, block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig, backend Backend) (map[string]interface{}, error) {
+	fields := RPCMarshalHeader(block.Header())
+	fields["size"] = hexutil.Uint64(block.Size())
+
+	if inclTx {
+		formatTx := func(idx int, tx *types.Transaction) interface{} {
+			return tx.Hash()
+		}
+		if fullTx {
+			formatTx = func(idx int, tx *types.Transaction) interface{} {
+				return newRPCTransactionFromBlockIndex(ctx, block, uint64(idx), config, backend)
+			}
+		}
+		txs := block.Transactions()
+		transactions := make([]interface{}, len(txs))
+		for i, tx := range txs {
+			transactions[i] = formatTx(i, tx)
+		}
+		fields["transactions"] = transactions
+	}
+	uncles := block.Uncles()
+	uncleHashes := make([]common.Hash, len(uncles))
+	for i, uncle := range uncles {
+		uncleHashes[i] = uncle.Hash()
+	}
+	fields["uncles"] = uncleHashes
+	if block.Header().WithdrawalsHash != nil {
+		fields["withdrawals"] = block.Withdrawals()
+	}
+	return fields, nil
+}
+
+// RPCMarshalHeader converts the given header to the RPC output .
+func RPCMarshalHeader(head *types.Header) map[string]interface{} {
+	result := map[string]interface{}{
+		"number":           (*hexutil.Big)(head.Number),
+		"hash":             head.Hash(),
+		"parentHash":       head.ParentHash,
+		"nonce":            head.Nonce,
+		"mixHash":          head.MixDigest,
+		"sha3Uncles":       head.UncleHash,
+		"logsBloom":        head.Bloom,
+		"stateRoot":        head.Root,
+		"miner":            head.Coinbase,
+		"difficulty":       (*hexutil.Big)(head.Difficulty),
+		"extraData":        hexutil.Bytes(head.Extra),
+		"gasLimit":         hexutil.Uint64(head.GasLimit),
+		"gasUsed":          hexutil.Uint64(head.GasUsed),
+		"timestamp":        hexutil.Uint64(head.Time),
+		"transactionsRoot": head.TxHash,
+		"receiptsRoot":     head.ReceiptHash,
+	}
+	if head.BaseFee != nil {
+		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
+	}
+	if head.WithdrawalsHash != nil {
+		result["withdrawalsRoot"] = head.WithdrawalsHash
+	}
+	if head.BlobGasUsed != nil {
+		result["blobGasUsed"] = hexutil.Uint64(*head.BlobGasUsed)
+	}
+	if head.ExcessBlobGas != nil {
+		result["excessBlobGas"] = hexutil.Uint64(*head.ExcessBlobGas)
+	}
+	if head.ParentBeaconRoot != nil {
+		result["parentBeaconBlockRoot"] = head.ParentBeaconRoot
+	}
+	return result
+}
+
+// newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
+func newRPCTransactionFromBlockIndex(ctx context.Context, b *types.Block, index uint64, config *params.ChainConfig, backend Backend) *RPCTransaction {
+	txs := b.Transactions()
+	if index >= uint64(len(txs)) {
+		return nil
+	}
+	tx := txs[index]
+	rcpt := depositTxReceipt(ctx, b.Hash(), index, backend, tx)
+	return newRPCTransaction(tx, b.Hash(), b.NumberU64(), b.Time(), index, b.BaseFee(), config, rcpt)
+}
+
+func depositTxReceipt(ctx context.Context, blockHash common.Hash, index uint64, backend Backend, tx *types.Transaction) *types.Receipt {
+	if tx.Type() != types.DepositTxType {
+		return nil
+	}
+	receipts, err := backend.GetReceipts(ctx, blockHash)
+	if err != nil {
+		return nil
+	}
+	if index >= uint64(len(receipts)) {
+		return nil
+	}
+	return receipts[index]
+}
+
+// newRPCTransaction returns a transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, blockTime uint64, index uint64, baseFee *big.Int, config *params.ChainConfig, receipt *types.Receipt) *RPCTransaction {
+	signer := types.MakeSigner(config, new(big.Int).SetUint64(blockNumber), blockTime)
+	from, _ := types.Sender(signer, tx)
+	v, r, s := tx.RawSignatureValues()
+	result := &RPCTransaction{
+		Type:     hexutil.Uint64(tx.Type()),
+		From:     from,
+		Gas:      hexutil.Uint64(tx.Gas()),
+		GasPrice: (*hexutil.Big)(tx.GasPrice()),
+		Hash:     tx.Hash(),
+		Input:    hexutil.Bytes(tx.Data()),
+		Nonce:    hexutil.Uint64(tx.Nonce()),
+		To:       tx.To(),
+		Value:    (*hexutil.Big)(tx.Value()),
+		V:        (*hexutil.Big)(v),
+		R:        (*hexutil.Big)(r),
+		S:        (*hexutil.Big)(s),
+	}
+	if blockHash != (common.Hash{}) {
+		result.BlockHash = &blockHash
+		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
+		result.TransactionIndex = (*hexutil.Uint64)(&index)
+	}
+
+	switch tx.Type() {
+	case types.DepositTxType:
+		srcHash := tx.SourceHash()
+		isSystemTx := tx.IsSystemTx()
+		result.SourceHash = &srcHash
+		if isSystemTx {
+			// Only include IsSystemTx when true
+			result.IsSystemTx = &isSystemTx
+		}
+		result.Mint = (*hexutil.Big)(tx.Mint())
+		if receipt != nil && receipt.DepositNonce != nil {
+			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
+			if receipt.DepositReceiptVersion != nil {
+				result.DepositReceiptVersion = new(hexutil.Uint64)
+				*result.DepositReceiptVersion = hexutil.Uint64(*receipt.DepositReceiptVersion)
+			}
+		}
+	case types.LegacyTxType:
+		if v.Sign() == 0 && r.Sign() == 0 && s.Sign() == 0 { // pre-bedrock relayed tx does not have a signature
+			result.ChainID = (*hexutil.Big)(new(big.Int).Set(config.ChainID))
+			break
+		}
+		// if a legacy transaction has an EIP-155 chain id, include it explicitly
+		if id := tx.ChainId(); id.Sign() != 0 {
+			result.ChainID = (*hexutil.Big)(id)
+		}
+
+	case types.AccessListTxType:
+		al := tx.AccessList()
+		yparity := hexutil.Uint64(v.Sign())
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.YParity = &yparity
+
+	case types.DynamicFeeTxType:
+		al := tx.AccessList()
+		yparity := hexutil.Uint64(v.Sign())
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.YParity = &yparity
+		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
+		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
+		// if the transaction has been mined, compute the effective gas price
+		if baseFee != nil && blockHash != (common.Hash{}) {
+			// price = min(gasTipCap + baseFee, gasFeeCap)
+			result.GasPrice = (*hexutil.Big)(effectiveGasPrice(tx, baseFee))
+		} else {
+			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
+		}
+
+	case types.BlobTxType:
+		al := tx.AccessList()
+		yparity := hexutil.Uint64(v.Sign())
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.YParity = &yparity
+		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
+		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
+		// if the transaction has been mined, compute the effective gas price
+		if baseFee != nil && blockHash != (common.Hash{}) {
+			result.GasPrice = (*hexutil.Big)(effectiveGasPrice(tx, baseFee))
+		} else {
+			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
+		}
+		result.MaxFeePerBlobGas = (*hexutil.Big)(tx.BlobGasFeeCap())
+		result.BlobVersionedHashes = tx.BlobHashes()
+	}
+	return result
+}
+
+// effectiveGasPrice computes the transaction gas fee, based on the given basefee value.
+//
+//	price = min(gasTipCap + baseFee, gasFeeCap)
+func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
+	fee := tx.GasTipCap()
+	fee = fee.Add(fee, baseFee)
+	if tx.GasFeeCapIntCmp(fee) < 0 {
+		return tx.GasFeeCap()
+	}
+	return fee
+}

--- a/eth/internal/ethapi/backend.go
+++ b/eth/internal/ethapi/backend.go
@@ -1,0 +1,12 @@
+package ethapi
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	types "github.com/ethereum/go-ethereum/core/types"
+)
+
+type Backend interface {
+	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
+}

--- a/eth/internal/ethapi/helpers.go
+++ b/eth/internal/ethapi/helpers.go
@@ -1,0 +1,19 @@
+package ethapi
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type noopBackend struct{}
+
+func (noopBackend) GetReceipts(_ context.Context, _ common.Hash) (types.Receipts, error) {
+	return nil, nil
+}
+
+func SimpleRPCMarshalBlock(block *types.Block, fullTx bool) (map[string]interface{}, error) {
+	return RPCMarshalBlock(context.Background(), block, true, fullTx, &params.ChainConfig{}, noopBackend{})
+}

--- a/monomer_test.go
+++ b/monomer_test.go
@@ -1,0 +1,19 @@
+package monomer_test
+
+import (
+	"testing"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/polymerdao/monomer/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockToEth(t *testing.T) {
+	l1InfoTx, depositTx, cosmosEthTx := testutils.GenerateEthTxs(t)
+	block := testutils.GenerateBlockFromEthTxs(t, l1InfoTx, []*ethtypes.Transaction{depositTx}, []*ethtypes.Transaction{cosmosEthTx})
+	ethBlock, err := block.ToEth()
+	require.NoError(t, err)
+	for i, ethTx := range []*ethtypes.Transaction{l1InfoTx, depositTx, cosmosEthTx} {
+		require.EqualExportedValues(t, ethTx, ethBlock.Body().Transactions[i])
+	}
+}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -1,10 +1,22 @@
 package testutils
 
 import (
+	"math/big"
+	"math/rand"
 	"testing"
 
 	cometdb "github.com/cometbft/cometbft-db"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/polymerdao/monomer"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,4 +34,56 @@ func NewMemDB(t *testing.T) dbm.DB {
 		require.NoError(t, db.Close())
 	})
 	return db
+}
+
+// GenerateEthTxs generates an L1 attributes tx, deposit tx, and cosmos tx packed in an Ethereum transaction.
+// The transactions are not meant to be executed.
+func GenerateEthTxs(t *testing.T) (*types.Transaction, *types.Transaction, *types.Transaction) {
+	timestamp := uint64(0)
+	l1Block := types.NewBlock(&types.Header{
+		BaseFee:    big.NewInt(10),
+		Difficulty: common.Big0,
+		Number:     big.NewInt(0),
+		Time:       timestamp,
+	}, nil, nil, nil, trie.NewStackTrie(nil))
+	l1InfoRawTx, err := derive.L1InfoDeposit(&rollup.Config{
+		Genesis:   rollup.Genesis{L2: eth.BlockID{Number: 0}},
+		L2ChainID: big.NewInt(1234),
+	}, eth.SystemConfig{}, 0, eth.BlockToInfo(l1Block), timestamp)
+	require.NoError(t, err)
+	l1InfoTx := types.NewTx(l1InfoRawTx)
+
+	rng := rand.New(rand.NewSource(1234))
+	depositTx := types.NewTx(testutils.GenerateDeposit(testutils.RandomHash(rng), rng))
+
+	cosmosEthTx := rolluptypes.AdaptNonDepositCosmosTxToEthTx([]byte{1})
+	return l1InfoTx, depositTx, cosmosEthTx
+}
+
+func GenerateBlockFromEthTxs(t *testing.T, l1InfoTx *types.Transaction, depositTxs, cosmosEthTxs []*types.Transaction) *monomer.Block {
+	l1InfoTxBytes, err := l1InfoTx.MarshalBinary()
+	require.NoError(t, err)
+	ethTxBytes := []hexutil.Bytes{l1InfoTxBytes}
+	for _, depositTx := range depositTxs {
+		depositTxBytes, err := depositTx.MarshalBinary()
+		require.NoError(t, err)
+		ethTxBytes = append(ethTxBytes, depositTxBytes)
+	}
+	for _, cosmosEthTx := range cosmosEthTxs {
+		cosmosEthTxBytes, err := cosmosEthTx.MarshalBinary()
+		require.NoError(t, err)
+		ethTxBytes = append(ethTxBytes, cosmosEthTxBytes)
+	}
+	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxBytes)
+	require.NoError(t, err)
+	return &monomer.Block{
+		Header: &monomer.Header{},
+		Txs:    cosmosTxs,
+	}
+}
+
+// GenerateBlock generates a valid block (up to stateless validation). The block is not meant to be executed.
+func GenerateBlock(t *testing.T) *monomer.Block {
+	l1InfoTx, depositTx, cosmosEthTx := GenerateEthTxs(t)
+	return GenerateBlockFromEthTxs(t, l1InfoTx, []*types.Transaction{depositTx}, []*types.Transaction{cosmosEthTx})
 }


### PR DESCRIPTION
The OP stack requires blocks returned from the `eth` API to be internally consistent. For example: the `block_hash` in the json must represent the hash of the Ethereum block, as defined by Ethereum. Monomer was using a slightly different block hash algorithm that excluded the tx root.

This changes Monomer's block hash algorithm to match Ethereum's. Furthermore, we copy op-geth's rpc marshalling code to ensure compatbility.

There are still errors in the e2e test (op-batcher not able to sign txs). Those can be fixed in follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced block retrieval methods for better performance and clearer logic.
	- Introduced a structured implementation for Ethereum's RPC API to streamline transaction handling.
	- Added a new method for converting blocks to an Ethereum format with improved error handling.
	- Added new utility functions to generate Ethereum transactions and blocks for testing.

- **Bug Fixes**
	- Improved handling of hash retrieval in the block structure.

- **Documentation**
	- Updated internal documentation to reflect changes in block serialization and RPC interactions.

- **Tests**
	- Adjusted test cases for block retrieval methods to account for recent changes in functionality.
	- Introduced new tests for verifying block conversion to Ethereum format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->