### PR TITLE
Configure tx-manager with its address

### DIFF
--- a/e2e/op_stack.go
+++ b/e2e/op_stack.go
@@ -244,7 +244,6 @@ func (op *OPStack) runBatcher(ctx context.Context, env *environment.Env, l1Clien
 		return fmt.Errorf("start batch submitting: %v", err)
 	}
 
-	fmt.Println("batcher started")
 	/*
 		There appears to be a deadlock in StopBatchSubmitting.
 		This was most likely fixed in a more recent OP-stack version, based on the significant diff.

--- a/e2e/op_stack.go
+++ b/e2e/op_stack.go
@@ -109,6 +109,7 @@ func (op *OPStack) Run(ctx context.Context, env *environment.Env) error {
 		Signer: func(ctx context.Context, address common.Address, tx *ethtypes.Transaction) (*ethtypes.Transaction, error) {
 			return opcrypto.PrivateKeySignerFn(op.privKey, l1ChainID)(address, tx)
 		},
+		From: crypto.PubkeyToAddress(op.privKey.PublicKey),
 	}
 
 	if err := op.runProposer(ctx, env, l1, txManagerConfig); err != nil {
@@ -242,6 +243,8 @@ func (op *OPStack) runBatcher(ctx context.Context, env *environment.Env, l1Clien
 	if err := batchSubmitter.StartBatchSubmitting(); err != nil {
 		return fmt.Errorf("start batch submitting: %v", err)
 	}
+
+	fmt.Println("batcher started")
 	/*
 		There appears to be a deadlock in StopBatchSubmitting.
 		This was most likely fixed in a more recent OP-stack version, based on the significant diff.


### PR DESCRIPTION
Previously, batcher submissions to L1 were failing with a message like `not authorized to sign for this account`. This is because the transaction signer address was not set, so was implicitly being set to the zero address.

e2e test logs now (usually) contain batcher logs as below, which is good behaviour.

```log
7331:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=f010c7..6edcc4:367 monomer-e2e-component=batcher                     
7333:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=0f98d0..a9a16d:368 monomer-e2e-component=batcher                                       
7334:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=4f7a6a..617cd1:369 monomer-e2e-component=batcher                                               
7335:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=036e81..c8e24e:370 monomer-e2e-component=batcher
7339:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=403212..397eee:371 monomer-e2e-component=batcher
7341:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=a18d49..739b2e:372 monomer-e2e-component=batcher
7342:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=1abab8..a0aa11:373 monomer-e2e-component=batcher
7343:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=c09824..4df2b4:374 monomer-e2e-component=batcher                                               7344:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=6d9611..2e561e:375 monomer-e2e-component=batcher                                               
7345:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=0794c8..bdc1a3:376 monomer-e2e-component=batcher                                          
7346:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=4652e3..0b98c1:377 monomer-e2e-component=batcher                                          
7347:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=d35ea2..49bb51:378 monomer-e2e-component=batcher                                       
7348:DEBUG[07-24|10:24:45.850] Added block to channel                   id=fa73f2..3f011e                     block=5a16ae..82a1d8:379 monomer-e2e-component=batcher                                               
7350:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=782753..a43ee3:380 monomer-e2e-component=batcher
7351:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=244bac..6e5b67:381 monomer-e2e-component=batcher
7352:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=4aafc2..8060af:382 monomer-e2e-component=batcher
7353:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=87c808..1f53c4:383 monomer-e2e-component=batcher
7354:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=c31224..b9c75f:384 monomer-e2e-component=batcher
7355:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=46a083..a13351:385 monomer-e2e-component=batcher                                               
7356:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=abf44a..25493b:386 monomer-e2e-component=batcher                                          
7357:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=53e46e..4323ef:387 monomer-e2e-component=batcher                                          
7358:DEBUG[07-24|10:24:45.851] Added block to channel                   id=fa73f2..3f011e                     block=d1d06f..127477:388 monomer-e2e-component=batcher
7359:DEBUG[07-24|10:24:45.851] Added blocks to channel                  blocks_added=22 blocks_pending=0  channel_full=false input_bytes=1716 ready_bytes=2 monomer-e2e-component=batcher
7360:DEBUG[07-24|10:24:45.851] new L1-block registered at channel builder l1Head=1eb126..7972ea:1 channel_full=true  full_reason="channel full: max channel duration reached" monomer-e2e-component=batcher
7361:INFO [07-24|10:24:45.851] Channel closed                           id=fa73f2..3f011e                     blocks_pending=0  num_frames=1 input_bytes=1716 output_bytes=946  l1_origin=000000..000000:0 full_rea
son="channel full: max channel duration reached" compr_ratio=0.551 latest_l1_origin=9bb975..39fb2c:0 monomer-e2e-component=batcher                                  
7362:DEBUG[07-24|10:24:45.851] returning next tx data                   id=fa73f234254b0734ca6444ca953f011e:0 num_frames=1 monomer-e2e-component=batcher            
7363:INFO [07-24|10:24:45.851] building Calldata transaction candidate  size=947  monomer-e2e-component=batcher                                                     
7364:DEBUG[07-24|10:24:45.851] crafting Transaction                     blobs=0 calldata_size=947  monomer-e2e-component=batcher-tx-manager service=batcher                              
7367:DEBUG[07-24|10:24:45.851] Requested tx data                        l1Head=1eb126..7972ea:1 txdata_pending=false blocks_pending=0  monomer-e2e-component=batcher                                       
7368:TRACE[07-24|10:24:45.851] no transaction data available            monomer-e2e-component=batcher                                                                                                              7373:INFO [07-24|10:24:45.851] Publishing transaction                   monomer-e2e-component=batcher-tx-manager service=batcher tx=479f3b..98c4ad nonce=18 gasTipCap=1 gasFeeCap=1,750,000,001 gasLimit=36056
7374:INFO [07-24|10:24:45.852] Transaction successfully published       monomer-e2e-component=batcher-tx-manager service=batcher tx=479f3b..98c4ad nonce=18 gasTipCap=1 gasFeeCap=1,750,000,001 gasLimit=36056
7600:INFO [07-24|10:24:45.891] added L2 block to local state            block=505843..e5464c:389 tx_count=1 time=1,690,834,119 monomer-e2e-component=batcher                                                       
7605:INFO [07-24|10:24:45.891] added L2 block to local state            block=33c497..acb3b3:390 tx_count=1 time=1,690,834,121 monomer-e2e-component=batcher                                                       
7611:INFO [07-24|10:24:45.892] added L2 block to local state            block=7f3e53..78d6a6:391 tx_count=1 time=1,690,834,123 monomer-e2e-component=batcher        
7615:INFO [07-24|10:24:45.893] added L2 block to local state            block=6ee59a..b93e6f:392 tx_count=1 time=1,690,834,125 monomer-e2e-component=batcher  
```

_Usually?_ Yes - the e2e test seems to wobble a little for me locally. 80% of the time it produces ~9k log lines, and shows the below. The other 20% produces 350-600 log lines, and doesn't doesn't contain the same iterations of a batcher adding blocks and submitting transactions. The tests pass in both cases.

Will defer thorough investigation - getting a validator node into the e2e, with a longer run time, should shake out most of this stuff.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction processing by adding a public address field to the configuration in the Run method, improving clarity on the source address for transactions.

- **Style**
	- Improved code readability by adding a blank line in the runBatcher method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->