### PR TITLE
L1 Deposit Tx

### DIFF
--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -34,6 +34,8 @@ type EventListener interface {
 type StackConfig struct {
 	L1URL *url.URL
 	*rollup.Config
+	Operator L1User
+	Users    []L1User
 }
 
 type Stack struct {
@@ -114,6 +116,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, er
 	}
 
 	// Fund test EOA accounts
+	l1users := make([]L1User, 0)
 	for range 1 {
 		privateKey, err := crypto.GenerateKey()
 		if err != nil {
@@ -127,7 +130,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, er
 			Address: &userAddress,
 		}
 		l1state.OnAccount(user.Address, user)
-		s.L1Users = append(s.L1Users, L1User{
+		l1users = append(l1users, L1User{
 			Address:    userAddress,
 			PrivateKey: privateKey,
 		})
@@ -187,7 +190,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, er
 		s.monomerEngineURL,
 		s.opNodeURL,
 		l1Deployments.L2OutputOracleProxy,
-		s.L1Users[0].PrivateKey,
+		l1users[0].PrivateKey,
 		rollupConfig,
 		s.eventListener,
 	)
@@ -196,8 +199,10 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, er
 	}
 
 	return &StackConfig{
-		L1URL:  l1url,
-		Config: rollupConfig,
+		L1URL:    l1url,
+		Config:   rollupConfig,
+		Operator: s.L1Users[0],
+		Users:    l1users[1:],
 	}, nil
 }
 

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -47,7 +47,6 @@ type Stack struct {
 	eventListener    EventListener
 	l1BlockTime      uint64
 	prometheusCfg    *config.InstrumentationConfig
-	L1Users          []L1User
 }
 
 type L1User struct {
@@ -117,7 +116,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, er
 
 	// Fund test EOA accounts
 	l1users := make([]L1User, 0)
-	for range 1 {
+	for range 2 {
 		privateKey, err := crypto.GenerateKey()
 		if err != nil {
 			return nil, fmt.Errorf("generate key: %v", err)
@@ -201,7 +200,7 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, er
 	return &StackConfig{
 		L1URL:    l1url,
 		Config:   rollupConfig,
-		Operator: s.L1Users[0],
+		Operator: l1users[0],
 		Users:    l1users[1:],
 	}, nil
 }

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cometbft/cometbft/config"
 	dbm "github.com/cosmos/cosmos-db"
 	opgenesis "github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -28,6 +29,11 @@ import (
 type EventListener interface {
 	OPEventListener
 	node.EventListener
+}
+
+type StackConfig struct {
+	L1URL *url.URL
+	*rollup.Config
 }
 
 type Stack struct {
@@ -71,17 +77,17 @@ func New(
 	}
 }
 
-func (s *Stack) Run(ctx context.Context, env *environment.Env) error {
+func (s *Stack) Run(ctx context.Context, env *environment.Env) (*StackConfig, error) {
 	// configure & run L1
 
 	const networkName = "devnetL1"
 	l1Deployments, err := opgenesis.NewL1Deployments(filepath.Join(s.l1stateDumpDir, "addresses.json"))
 	if err != nil {
-		return fmt.Errorf("new l1 deployments: %v", err)
+		return nil, fmt.Errorf("new l1 deployments: %v", err)
 	}
 	deployConfig, err := opgenesis.NewDeployConfigWithNetwork(networkName, s.deployConfigDir)
 	if err != nil {
-		return fmt.Errorf("new deploy config: %v", err)
+		return nil, fmt.Errorf("new deploy config: %v", err)
 	}
 	deployConfig.SetDeployments(l1Deployments)
 	deployConfig.L1UseClique = false // Allows node to produce blocks without addition config. Clique is a PoA config.
@@ -92,26 +98,26 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) error {
 	if err != nil {
 		// check if not found
 		if os.IsNotExist(err) {
-			return fmt.Errorf("allocs-l1.json not found - run `make setup-e2e` from project root")
+			return nil, fmt.Errorf("allocs-l1.json not found - run `make setup-e2e` from project root")
 		} else {
-			return fmt.Errorf("read allocs-l1.json: %v", err)
+			return nil, fmt.Errorf("read allocs-l1.json: %v", err)
 		}
 	}
 	err = json.Unmarshal(l1StateJSON, &auxState)
 	if err != nil {
-		return fmt.Errorf("unmarshal l1 state: %v", err)
+		return nil, fmt.Errorf("unmarshal l1 state: %v", err)
 	}
 
 	l1state, err := auxState.ToStateDump()
 	if err != nil {
-		return fmt.Errorf("auxState to state dump: %v", err)
+		return nil, fmt.Errorf("auxState to state dump: %v", err)
 	}
 
 	// Fund test EOA accounts
 	for range 1 {
 		privateKey, err := crypto.GenerateKey()
 		if err != nil {
-			return fmt.Errorf("generate key: %v", err)
+			return nil, fmt.Errorf("generate key: %v", err)
 		}
 		userAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
 
@@ -129,51 +135,51 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) error {
 
 	l1genesis, err := opgenesis.BuildL1DeveloperGenesis(deployConfig, l1state, l1Deployments)
 	if err != nil {
-		return fmt.Errorf("build l1 developer genesis: %v", err)
+		return nil, fmt.Errorf("build l1 developer genesis: %v", err)
 	}
 
 	l1client, l1HTTPendpoint, err := gethdevnet(s.l1BlockTime, l1genesis)
 	if err != nil {
-		return fmt.Errorf("ethdevnet: %v", err)
+		return nil, fmt.Errorf("ethdevnet: %v", err)
 	}
 
 	l1url, err := url.ParseString(l1HTTPendpoint)
 	if err != nil {
-		return fmt.Errorf("new l1 url: %v", err)
+		return nil, fmt.Errorf("new l1 url: %v", err)
 	}
 
 	// NOTE: should we set a timeout on the context? Might not be worth the complexity.
 	if !l1url.IsReachable(ctx) {
-		return fmt.Errorf("l1 url not reachable: %s", l1url.String())
+		return nil, fmt.Errorf("l1 url not reachable: %s", l1url.String())
 	}
 
 	l1 := NewL1Client(l1client)
 
 	latestL1Block, err := l1.BlockByNumber(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("get the latest l1 block: %v", err)
+		return nil, fmt.Errorf("get the latest l1 block: %v", err)
 	}
 
 	// Run Monomer.
 	if err := s.runMonomer(ctx, env, latestL1Block.Time(), deployConfig.L2ChainID); err != nil {
-		return err
+		return nil, err
 	}
 	if !s.monomerEngineURL.IsReachable(ctx) {
-		return nil
+		return nil, fmt.Errorf("reaching monomer url: %s", s.monomerEngineURL.String())
 	}
 	monomerRPCClient, err := rpc.DialContext(ctx, s.monomerEngineURL.String())
 	if err != nil {
-		return fmt.Errorf("dial monomer: %v", err)
+		return nil, fmt.Errorf("dial monomer: %v", err)
 	}
 	monomerClient := NewMonomerClient(monomerRPCClient)
 	l2GenesisBlockHash, err := monomerClient.GenesisHash(ctx)
 	if err != nil {
-		return fmt.Errorf("get Monomer genesis block hash: %v", err)
+		return nil, fmt.Errorf("get Monomer genesis block hash: %v", err)
 	}
 
 	rollupConfig, err := deployConfig.RollupConfig(latestL1Block, l2GenesisBlockHash, 1)
 	if err != nil {
-		return fmt.Errorf("new rollup config: %v", err)
+		return nil, fmt.Errorf("new rollup config: %v", err)
 	}
 
 	opStack := NewOPStack(
@@ -186,9 +192,13 @@ func (s *Stack) Run(ctx context.Context, env *environment.Env) error {
 		s.eventListener,
 	)
 	if err := opStack.Run(ctx, env); err != nil {
-		return fmt.Errorf("run the op stack: %v", err)
+		return nil, fmt.Errorf("run the op stack: %v", err)
 	}
-	return nil
+
+	return &StackConfig{
+		L1URL:  l1url,
+		Config: rollupConfig,
+	}, nil
 }
 
 func (s *Stack) runMonomer(ctx context.Context, env *environment.Env, genesisTime, chainIDU64 uint64) error {

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -224,12 +224,8 @@ func TestE2E(t *testing.T) {
 			require.NoError(t, err)
 			require.Fail(t, fmt.Sprintf("expected tx to be deposit tx: %s", txBytes))
 		}
-		if len(txs) > 1 {
-			t.Logf("%d txs", len(txs))
-		}
 	}
 	t.Log("Monomer blocks contain the l1 attributes deposit tx")
-	// time.Sleep(15 * time.Second)
 }
 
 func newURL(t *testing.T, address string) *e2eurl.URL {

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -143,7 +143,7 @@ func TestE2E(t *testing.T) {
 			},
 			Nonce:    big.NewInt(int64(nonce)),
 			GasPrice: big.NewInt(price.Int64() * 2),
-			GasLimit: 1e6,
+			GasLimit: 1e7,
 			Value:    big.NewInt(1e18 / 10), // 0.1 eth
 			Context:  ctx,
 			NoSend:   false,

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -89,7 +89,8 @@ func TestE2E(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	require.NoError(t, stack.Run(ctx, env))
+	_, err = stack.Run(ctx, env)
+	require.NoError(t, err)
 	// To avoid flaky tests, hang until the Monomer server is ready.
 	// We rely on the `go test` timeout to ensure the tests don't hang forever (default is 10 minutes).
 	require.True(t, monomerEngineURL.IsReachable(ctx))

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 const artifactsDirectoryName = "artifacts"
+const oneEth = 1e18
 
 func openLogFile(t *testing.T, env *environment.Env, name string) *os.File {
 	filename := filepath.Join(artifactsDirectoryName, name+".log")
@@ -139,12 +140,12 @@ func TestE2E(t *testing.T) {
 			Nonce:    big.NewInt(int64(nonce)),
 			GasPrice: big.NewInt(gasPrice.Int64() * 2),
 			GasLimit: 1e7,
-			Value:    big.NewInt(1e18 / 10), // 0.1 eth
+			Value:    big.NewInt(oneEth / 10),
 			Context:  ctx,
 			NoSend:   false,
 		},
 		user.Address,
-		big.NewInt(1e18/20), // 0.5 eth deposit to L2
+		big.NewInt(oneEth/20),
 		stackConfig.Genesis.SystemConfig.GasLimit/10, // 10% of block gas limit
 		false,    // _isCreation
 		[]byte{}, // no data

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -140,12 +140,12 @@ func TestE2E(t *testing.T) {
 			Nonce:    big.NewInt(int64(nonce)),
 			GasPrice: big.NewInt(gasPrice.Int64() * 2),
 			GasLimit: 1e7,
-			Value:    big.NewInt(oneEth / 10),
+			Value:    big.NewInt(oneEth),
 			Context:  ctx,
 			NoSend:   false,
 		},
 		user.Address,
-		big.NewInt(oneEth/20),
+		big.NewInt(oneEth/2), // the "minting order" for L2
 		stackConfig.Genesis.SystemConfig.GasLimit/10, // 10% of block gas limit
 		false,    // _isCreation
 		[]byte{}, // no data
@@ -224,8 +224,12 @@ func TestE2E(t *testing.T) {
 			require.NoError(t, err)
 			require.Fail(t, fmt.Sprintf("expected tx to be deposit tx: %s", txBytes))
 		}
+		if len(txs) > 1 {
+			t.Logf("%d txs", len(txs))
+		}
 	}
 	t.Log("Monomer blocks contain the l1 attributes deposit tx")
+	// time.Sleep(15 * time.Second)
 }
 
 func newURL(t *testing.T, address string) *e2eurl.URL {

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -123,13 +123,8 @@ func TestE2E(t *testing.T) {
 	nonce, err := l1Client.Client.NonceAt(ctx, user.Address, nil)
 	require.NoError(t, err)
 
-	price, err := l1Client.Client.SuggestGasPrice(context.Background())
+	gasPrice, err := l1Client.Client.SuggestGasPrice(context.Background())
 	require.NoError(t, err)
-
-	gasPrice := new(big.Int).Mul(price, big.NewInt(2))
-	if gasPrice.BitLen() > 256 {
-		gasPrice = price // fallback to original price if overflow
-	}
 
 	depositTx, err := portal.DepositTransaction(
 		&bind.TransactOpts{
@@ -142,7 +137,7 @@ func TestE2E(t *testing.T) {
 				return signed, nil
 			},
 			Nonce:    big.NewInt(int64(nonce)),
-			GasPrice: big.NewInt(price.Int64() * 2),
+			GasPrice: big.NewInt(gasPrice.Int64() * 2),
 			GasLimit: 1e7,
 			Value:    big.NewInt(1e18 / 10), // 0.1 eth
 			Context:  ctx,

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -129,6 +129,9 @@ func TestE2E(t *testing.T) {
 	gasPrice, err := l1Client.Client.SuggestGasPrice(context.Background())
 	require.NoError(t, err)
 
+	l2GasLimit := stackConfig.Genesis.SystemConfig.GasLimit / 10 // 10% of block gas limit
+	l1GasLimit := l2GasLimit * 2                                 // must be higher than l2Gaslimit, because of l1 gas burn (cross-chain gas accounting)
+
 	depositTx, err := portal.DepositTransaction(
 		&bind.TransactOpts{
 			From: user.Address,
@@ -141,14 +144,14 @@ func TestE2E(t *testing.T) {
 			},
 			Nonce:    big.NewInt(int64(nonce)),
 			GasPrice: big.NewInt(gasPrice.Int64() * 2),
-			GasLimit: 1e7,
+			GasLimit: l1GasLimit,
 			Value:    big.NewInt(oneEth),
 			Context:  ctx,
 			NoSend:   false,
 		},
 		user.Address,
 		big.NewInt(oneEth/2), // the "minting order" for L2
-		stackConfig.Genesis.SystemConfig.GasLimit/10, // 10% of block gas limit
+		l2GasLimit,
 		false,    // _isCreation
 		[]byte{}, // no data
 	)

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -200,6 +200,7 @@ func TestE2E(t *testing.T) {
 	receipt, err := l1Client.Client.TransactionReceipt(ctx, depositTx.Hash())
 	require.NoError(t, err, "deposit tx receipt")
 	require.NotNil(t, receipt, "deposit tx receipt")
+	require.NotZero(t, receipt.Status, "deposit tx reverted") // receipt.Status == 0 -> reverted tx
 
 	for i := uint64(2); i < targetHeight; i++ {
 		block, err := monomerClient.BlockByNumber(ctx, new(big.Int).SetUint64(i))

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -213,8 +213,6 @@ func TestE2E(t *testing.T) {
 		}
 	}
 	t.Log("Monomer blocks contain the l1 attributes deposit tx")
-
-	time.Sleep(15 * time.Second)
 }
 
 func newURL(t *testing.T, address string) *e2eurl.URL {

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -30,8 +30,10 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-const artifactsDirectoryName = "artifacts"
-const oneEth = 1e18
+const (
+	artifactsDirectoryName = "artifacts"
+	oneEth                 = 1e18
+)
 
 func openLogFile(t *testing.T, env *environment.Env, name string) *os.File {
 	filename := filepath.Join(artifactsDirectoryName, name+".log")


### PR DESCRIPTION
PR is partial work toward an e2e deposit workflow. It:

- modifies `e2e.Stack.Run` to return some stack data for the test runner
- crafts and submits a deposit tx to the L1 deposit contract, via the op-bindings `portal`
- asserts that the tx landed on L1


The deposit tx is not being processed by Monomer. Likely because monomer's epoch does not advance, in turn likely related to some rollback issues.

To do (future PRs):
- [ ] assert that deposits are picked up from L1 by the node
- [ ] assert minting / balance changes on L2
- [ ] pack a deposit tx with transaction data, processed and executed by monomer

A concern:
- `stack_test.go` is becoming a little unwieldy. May be worth a focused refactor at some point to extract some sort of `action,result` table test so that causes and observable effects can be coupled together more effectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced the stack's functionality to return detailed configuration information alongside error handling.
  - Introduced a new `StackConfig` structure for better management of configuration parameters.
  - Integrated Layer 1 interactions for deposit transactions in end-to-end tests, including transaction signing and verification.

- **Bug Fixes**
  - Improved error management in the stack setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->