### PR TITLE
Split NewBlock and SetHeader out from MakeBlock

### DIFF
--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -74,7 +74,7 @@ func TestABCI(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	blockStore := store.NewBlockStore(testutils.NewMemDB(t))
-	headBlock, err := monomer.MakeBlock(&monomer.Header{}, nil)
+	headBlock, err := monomer.MakeBlock(&monomer.Header{}, bfttypes.Txs{})
 	require.NoError(t, err)
 	blockStore.AddBlock(headBlock)
 	headCometBlock := headBlock.ToCometLikeBlock()
@@ -340,7 +340,7 @@ func TestBlock(t *testing.T) {
 	blockStore := store.NewBlockStore(testutils.NewMemDB(t))
 	block, err := monomer.MakeBlock(&monomer.Header{
 		Height: 3,
-	}, nil)
+	}, bfttypes.Txs{})
 	require.NoError(t, err)
 	cometBlock := block.ToCometLikeBlock()
 	want := &rpctypes.ResultBlock{

--- a/eth/block_id_test.go
+++ b/eth/block_id_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	bfttypes "github.com/cometbft/cometbft/types"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
@@ -59,7 +60,7 @@ func TestBlockIDUnmarshalValidJSON(t *testing.T) {
 
 func TestBlockIDGet(t *testing.T) {
 	blockStore := store.NewBlockStore(testutils.NewMemDB(t))
-	block, err := monomer.MakeBlock(&monomer.Header{}, nil)
+	block, err := monomer.MakeBlock(&monomer.Header{}, bfttypes.Txs{})
 	require.NoError(t, err)
 	blockStore.AddBlock(block)
 	require.NoError(t, blockStore.UpdateLabel(opeth.Unsafe, block.Header.Hash))

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	bfttypes "github.com/cometbft/cometbft/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
@@ -44,7 +45,7 @@ func (g *Genesis) Commit(ctx context.Context, app monomer.Application, blockStor
 		ChainID:  g.ChainID,
 		Time:     g.Time,
 		GasLimit: defaultGasLimit,
-	}, nil)
+	}, bfttypes.Txs{})
 	if err != nil {
 		return fmt.Errorf("make block: %v", err)
 	}

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	bfttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/polymerdao/monomer"
@@ -69,7 +70,7 @@ func TestCommit(t *testing.T) {
 				Height:   info.GetLastBlockHeight(),
 				Time:     test.genesis.Time,
 				GasLimit: 30_000_000, // We cheat a little and copy the default gas limit here.
-			}, nil)
+			}, bfttypes.Txs{})
 			require.NoError(t, err)
 			require.Equal(t, block, blockStore.BlockByNumber(info.GetLastBlockHeight()))
 			require.Equal(t, block, blockStore.BlockByLabel(eth.Unsafe))

--- a/monomer.go
+++ b/monomer.go
@@ -70,19 +70,31 @@ type Block struct {
 	Txs    bfttypes.Txs `json:"txs"`
 }
 
-// MakeBlock creates a new block. It calculates stateless properties on the header (like the block hash) and resets them.
-// The header must be non-nil. The txs may be nil.
-func MakeBlock(h *Header, txs bfttypes.Txs) (*Block, error) {
-	block := &Block{
+// NewBlock creates a new block. The header and txs must be non-nil. It performs no other validation.
+func NewBlock(h *Header, txs bfttypes.Txs) *Block {
+	if h == nil || txs == nil {
+		panic("header or txs is nil")
+	}
+	return &Block{
 		Header: h,
 		Txs:    txs,
 	}
+}
+
+// SetHeader calculates the extrinsic properties on the header (like the block hash) and resets them.
+// It assumes the block has been created with NewBlock.
+func SetHeader(block *Block) (*Block, error) {
 	ethBlock, err := block.ToEth()
 	if err != nil {
 		return nil, fmt.Errorf("convert block to Ethereum representation: %v", err)
 	}
 	block.Header.Hash = ethBlock.Hash()
 	return block, nil
+}
+
+// MakeBlock creates a block and calculates the extrinsic properties on the header (like the block hash).
+func MakeBlock(h *Header, txs bfttypes.Txs) (*Block, error) {
+	return SetHeader(NewBlock(h, txs))
 }
 
 func (b *Block) ToEth() (*ethtypes.Block, error) {


### PR DESCRIPTION
This will be useful in cases where we don't need to recalculate the hash.