### PR TITLE
Adapters-unit-tests

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -110,7 +110,7 @@ func AdaptCosmosTxsToEthTxs(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, erro
 	for _, txBytes := range ethTxsBytes {
 		var tx ethtypes.Transaction
 		if err := tx.UnmarshalBinary(txBytes); err != nil {
-			break
+			return nil, fmt.Errorf("unmarshal binary: %v", err)
 		}
 		if !tx.IsDepositTx() {
 			return nil, errors.New("MsgL1Tx contains non-deposit tx")

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -80,7 +80,7 @@ func TestBuild(t *testing.T) {
 
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
-			inclusionListTxs := testapp.ToTxs(t, test.inclusionList)
+			inclusionListTxs := append([][]byte{testutils.GenerateBlock(t).Txs[0]}, testapp.ToTxs(t, test.inclusionList)...)
 			mempoolTxs := testapp.ToTxs(t, test.mempool)
 
 			pool := mempool.New(testutils.NewMemDB(t))
@@ -246,7 +246,7 @@ func TestRollback(t *testing.T) {
 	}
 	block, err := b.Build(context.Background(), &builder.Payload{
 		Timestamp:            g.Time + 1,
-		InjectedTransactions: bfttypes.ToTxs(testapp.ToTxs(t, kvs)),
+		InjectedTransactions: bfttypes.ToTxs(append([][]byte{testutils.GenerateBlock(t).Txs[0]}, testapp.ToTxs(t, kvs)...)),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, block)

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -105,7 +105,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 		t.Run("unmarshal binary error", func(t *testing.T) {
 			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{[]byte("invalid")})
 			require.Nil(t, cosmosTxs)
-			require.ErrorContains(t, err, "unmarshal binary")
+			require.Error(t, err)
 		})
 		t.Run("zero deposit txs", func(t *testing.T) {
 			inner := generateDynamicFeeInner(r)
@@ -137,7 +137,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 
 			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depTxBytes, nonDepTxBytes, []byte("invalid")})
 			require.Nil(t, cosmosTxs)
-			require.ErrorContains(t, err, "unmarshal binary tx: ")
+			require.Error(t, err)
 		})
 	})
 }

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -62,14 +62,10 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 				ethTxs := make([]hexutil.Bytes, tc.depNum+tc.nonDepNum)
 				transactions := generateEthTransactions(t, tc.depNum, tc.nonDepNum)
 
-				depositTxsNum := 0
 				for i := range transactions {
 					txBinary, err := transactions[i].MarshalBinary()
 					require.NoError(t, err)
 					ethTxs[i] = txBinary
-					if transactions[i].IsDepositTx() {
-						depositTxsNum++
-					}
 				}
 
 				// Convert the binary format to a Cosmos transaction.
@@ -90,7 +86,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 				require.NoError(t, err)
 
 				// Copy the original transaction because time fields are different if not copied.
-				require.Equal(t, depositTxsNum, len(applyL1TxsRequest.TxBytes))
+				require.Equal(t, tc.depNum, len(applyL1TxsRequest.TxBytes))
 				for i, txBytes := range applyL1TxsRequest.TxBytes {
 					newTransaction := transactions[i]
 					err = newTransaction.UnmarshalBinary(txBytes)
@@ -99,7 +95,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 				}
 
 				for i := 1; i < len(cosmosTxs); i++ {
-					require.Equal(t, transactions[depositTxsNum-1+i].Data(), []byte(cosmosTxs[i]))
+					require.Equal(t, transactions[tc.depNum-1+i].Data(), []byte(cosmosTxs[i]))
 				}
 			})
 		}

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -342,7 +342,10 @@ func BenchmarkAdaptPayloadTxsToCosmosTxs(b *testing.B) {
 		ethTxs[i] = txBinary
 	}
 	for i := 0; i < b.N; i++ {
-		rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxs)
+		_, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxs)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -354,6 +357,9 @@ func BenchmarkAdaptCosmosTxsToEthTxs(b *testing.B) {
 	cosmosTxs := generateCosmosSDKTx(100, 1000, ethTxs)
 
 	for i := 0; i < b.N; i++ {
-		rolluptypes.AdaptCosmosTxsToEthTxs(cosmosTxs)
+		_, err := rolluptypes.AdaptCosmosTxsToEthTxs(cosmosTxs)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -15,7 +15,6 @@ import (
 	rollupv1 "github.com/polymerdao/monomer/gen/rollup/v1"
 	"github.com/polymerdao/monomer/testutils"
 	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +22,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 	t.Run("Zero txs", func(t *testing.T) {
 		cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{})
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(cosmosTxs))
+		require.Equal(t, 0, len(cosmosTxs))
 	})
 
 	src := rand.NewSource(0)
@@ -78,7 +77,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 				require.NoError(t, err)
 
 				if len(ethTxs) == 0 {
-					assert.Equal(t, 0, len(cosmosTxs))
+					require.Equal(t, 0, len(cosmosTxs))
 					return
 				}
 
@@ -91,16 +90,16 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 				require.NoError(t, err)
 
 				// Copy the original transaction because time fields are different if not copied.
-				assert.Equal(t, depositTxsNum, len(applyL1TxsRequest.TxBytes))
+				require.Equal(t, depositTxsNum, len(applyL1TxsRequest.TxBytes))
 				for i, txBytes := range applyL1TxsRequest.TxBytes {
 					newTransaction := transactions[i]
 					err = newTransaction.UnmarshalBinary(txBytes)
 					require.NoError(t, err)
-					assert.Equal(t, transactions[i], newTransaction)
+					require.Equal(t, transactions[i], newTransaction)
 				}
 
 				for i := 1; i < len(cosmosTxs); i++ {
-					assert.Equal(t, transactions[depositTxsNum-1+i].Data(), []byte(cosmosTxs[i]))
+					require.Equal(t, transactions[depositTxsNum-1+i].Data(), []byte(cosmosTxs[i]))
 				}
 			})
 		}
@@ -109,8 +108,8 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 	t.Run("non-zero txs with error", func(t *testing.T) {
 		t.Run("unmarshal binary error", func(t *testing.T) {
 			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{[]byte("invalid")})
-			assert.Nil(t, cosmosTxs)
-			assert.ErrorContains(t, err, "unmarshal binary")
+			require.Nil(t, cosmosTxs)
+			require.ErrorContains(t, err, "unmarshal binary")
 		})
 		t.Run("zero deposit txs", func(t *testing.T) {
 			inner := generateDynamicFeeInner(r)
@@ -118,8 +117,8 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 			txBytes, err := transaction.MarshalBinary()
 			require.NoError(t, err)
 			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{txBytes})
-			assert.Nil(t, cosmosTxs)
-			assert.Error(t, err)
+			require.Nil(t, cosmosTxs)
+			require.Error(t, err)
 		})
 		t.Run("NewAnyWithValue error", func(t *testing.T) {
 			t.Skip()
@@ -141,8 +140,8 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 			require.NoError(t, err)
 
 			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depTxBytes, nonDepTxBytes, []byte("invalid")})
-			assert.Nil(t, cosmosTxs)
-			assert.ErrorContains(t, err, "unmarshal binary tx: ")
+			require.Nil(t, cosmosTxs)
+			require.ErrorContains(t, err, "unmarshal binary tx: ")
 		})
 	})
 }
@@ -218,7 +217,7 @@ func TestAdaptCosmosTxsToEthTxs(t *testing.T) {
 	t.Run("Zero txs", func(t *testing.T) {
 		txs, err := rolluptypes.AdaptCosmosTxsToEthTxs(bfttypes.Txs{})
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(txs))
+		require.Equal(t, 0, len(txs))
 	})
 
 	t.Run("non-zero txs without error", func(t *testing.T) {
@@ -252,10 +251,10 @@ func TestAdaptCosmosTxsToEthTxs(t *testing.T) {
 				cosmosSDKTxs := generateCosmosSDKTx(tc.depNum, tc.nonDepNum, ethTxs)
 				adoptedTxs, err := rolluptypes.AdaptCosmosTxsToEthTxs(cosmosSDKTxs)
 				require.NoError(t, err)
-				assert.Equal(t, len(ethTxs), len(adoptedTxs))
+				require.Equal(t, len(ethTxs), len(adoptedTxs))
 				for i := range adoptedTxs {
 					ethTxs[0].SetTime(adoptedTxs[0].Time())
-					assert.Equal(t, ethTxs[i].Data(), adoptedTxs[i].Data())
+					require.Equal(t, ethTxs[i].Data(), adoptedTxs[i].Data())
 					// TODO: Incorrect adaptation of other fields
 				}
 			})

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -1,0 +1,130 @@
+package types_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	rollupv1 "github.com/polymerdao/monomer/gen/rollup/v1"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdaptPayloadTxsToCosmosTxs is a test function that demonstrates how to use
+// the AdaptPayloadTxsToCosmosTxs function from the rolluptypes package.
+//
+// The function creates a deposit transaction, marshals it into a binary format,
+// converts it to a Cosmos transaction, and then unmarshals it back into a
+// deposit transaction. The resulting deposit transaction is then compared to the
+// original one to ensure that the conversion process was successful.
+func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
+	// Define the necessary transaction parameters.
+	sourceHashString := "0x1234567890abcdef1234567890abcdef12345678"
+	fromAddressString := "0x1111111111111111111111111111111111111111"
+	toAddressString := "cosmos1recipientaddress"
+	value64 := int64(1_000_000_000_000_000_000) // 1 Ether = 1000000 uatom
+	gas := uint64(1_000_000)
+	data := []byte("test data")
+	mint := big.NewInt(1_000_000_000_000_000_000) // 1 Ether = 1000000 uatom
+	isSystemTransaction := false
+
+	// Convert the parameter values to Ethereum types.
+	sourceHash := common.HexToHash(sourceHashString)
+	fromAddress := common.HexToAddress(fromAddressString)
+	toAddress := common.HexToAddress(toAddressString)
+	value := big.NewInt(value64)
+
+	// Create a deposit transaction.
+	depInner := &types.DepositTx{
+		SourceHash:          sourceHash,
+		From:                fromAddress,
+		To:                  &toAddress,
+		Value:               value,
+		Gas:                 gas,
+		Data:                data,
+		Mint:                mint,
+		IsSystemTransaction: isSystemTransaction,
+	}
+
+	// Convert the deposit transaction to a binary format.
+	depTx := types.NewTx(depInner)
+
+	depTxBinary, err := depTx.MarshalBinary()
+	require.NoError(t, err)
+
+	// Convert the binary format to a Cosmos transaction.
+	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depTxBinary})
+	require.NoError(t, err)
+
+	// Unmarshal the first Cosmos transaction back into a deposit transaction.
+	decodedTx, err := unmarshalTx(cosmosTxs[0])
+	if err != nil {
+		require.NoError(t, err)
+	}
+	// Print the decoded transaction for debugging purposes.
+	fmt.Printf("%+v\n", decodedTx)
+
+	// Print the value of the first message in the decoded transaction for debugging purposes.
+	// body:<messages:<type_url:"/rollup.v1.ApplyL1TxsRequest" value:"\no~\370l\240\000\000\000\000\000\000\000\000\000\000\000\000\0224Vx\220\253\315\357\0224Vx\220\253\315\357\0224Vx\224\021\021\021\021\021\021\021\021\021\021\021\021\021\021\021\021\021\021\021\021\224\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\014\210\r\340\266\263\247d\000\000\210\r\340\266\263\247d\000\000\203\017B@\200\211test data" > >
+	fmt.Println()
+	fmt.Printf("%x\n", decodedTx.Body.Messages[0].Value)
+	// 0a6f7ef86ca00000000000000000000000001234567890abcdef1234567890abcdef1234567894111111111111111111111111111111111111111194000000000000000000000000000000000000000c880de0b6b3a7640000880de0b6b3a7640000830f42408089746573742064617461
+	fmt.Println()
+
+	// Unmarshal the first message in the decoded transaction back into a deposit transaction.
+	decodedTx, err = unmarshalTx(decodedTx.Body.Messages[0].Value)
+	require.NoError(t, err)
+
+	//  Error Trace:    /Users/daniilankusin/monomer/x/rollup/types/adapters_test.go:64
+	//             Error:          Received unexpected error:
+	//                             proto: illegal wireType 6
+
+	fmt.Printf("%+v\n", decodedTx)
+	fmt.Println()
+
+	// Unmarshal the first message in the decoded transaction back into a deposit transaction.
+	err = depTx.UnmarshalBinary(decodedTx.Body.Messages[0].Value)
+	require.NoError(t, err)
+
+	// Error Trace:    /Users/daniilankusin/monomer/x/rollup/types/adapters_test.go:75
+	//             Error:          Received unexpected error:
+	//                             transaction type not supported
+	//             Test:           TestAdaptPayloadTxsToCosmosTxs
+
+	fmt.Printf("%+v\n", depTx)
+	fmt.Println()
+}
+
+func registerInterfaces(interfaceRegistry codectypes.InterfaceRegistry) {
+	// Register SDK interfaces and concrete types
+	rollupv1.RegisterInterfaces(interfaceRegistry)
+}
+
+func makeProtoCodec() codec.ProtoCodecMarshaler {
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	registerInterfaces(interfaceRegistry)
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+	return cdc
+}
+
+func unmarshalTx(txBytes []byte) (*tx.Tx, error) {
+	// Initialize the codec
+	protoCodec := makeProtoCodec()
+
+	// Create a variable to hold the transaction
+	var transaction tx.Tx
+
+	// Unmarshal the transaction bytes
+	err := protoCodec.Unmarshal(txBytes, &transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	return &transaction, nil
+}

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -22,7 +22,7 @@ func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
 	t.Run("Zero txs", func(t *testing.T) {
 		cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{})
 		require.NoError(t, err)
-		require.Equal(t, 0, len(cosmosTxs))
+		require.Empty(t, cosmosTxs)
 	})
 
 	src := rand.NewSource(0)

--- a/x/rollup/types/adapters_test.go
+++ b/x/rollup/types/adapters_test.go
@@ -2,126 +2,212 @@ package types_test
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/types/tx"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	rollupv1 "github.com/polymerdao/monomer/gen/rollup/v1"
 	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestAdaptPayloadTxsToCosmosTxs is a test function that demonstrates how to use
-// the AdaptPayloadTxsToCosmosTxs function from the rolluptypes package.
-//
-// The function creates a deposit transaction, marshals it into a binary format,
-// converts it to a Cosmos transaction, and then unmarshals it back into a
-// deposit transaction. The resulting deposit transaction is then compared to the
-// original one to ensure that the conversion process was successful.
 func TestAdaptPayloadTxsToCosmosTxs(t *testing.T) {
-	// TODO: create an inner generator function to generate the test data
-	// Define the necessary transaction parameters.
-	sourceHashString := "0x1234567890abcdef1234567890abcdef12345678"
-	fromAddressString := "0x1111111111111111111111111111111111111111"
-	toAddressString := "cosmos1recipientaddress"
-	value64 := int64(1_000_000_000_000_000_000) // 1 Ether = 1000000 uatom
-	gas := uint64(1_000_000)
-	data := []byte("test data")
-	mint := big.NewInt(1_000_000_000_000_000_000) // 1 Ether = 1000000 uatom
-	isSystemTransaction := false
+	t.Run("Zero txs", func(t *testing.T) {
+		cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{})
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(cosmosTxs))
+	})
 
-	// Convert the parameter values to Ethereum types.
-	sourceHash := common.HexToHash(sourceHashString)
-	fromAddress := common.HexToAddress(fromAddressString)
-	toAddress := common.HexToAddress(toAddressString)
-	value := big.NewInt(value64)
+	src := rand.NewSource(0)
+	r := rand.New(src)
 
-	// Create a deposit transaction.
-	depInner := &types.DepositTx{
-		SourceHash:          sourceHash,
-		From:                fromAddress,
-		To:                  &toAddress,
-		Value:               value,
-		Gas:                 gas,
-		Data:                data,
-		Mint:                mint,
-		IsSystemTransaction: isSystemTransaction,
-	}
+	t.Run("non-zero txs without error", func(t *testing.T) {
+		testTable := []struct {
+			name   string
+			inners []ethtypes.TxData
+		}{
+			{
+				name:   "DepositTx",
+				inners: generateMultipleDepositTx(r, 1),
+			},
+			{
+				name:   "Multiple DepositTxs",
+				inners: generateMultipleDepositTx(r, 3),
+			},
+			{
+				name:   "DepositTx + AccessListTx",
+				inners: []ethtypes.TxData{generateDepositTx(r), generateDynamicFeeTx(r)},
+			},
+			{
+				name:   "Multiple DepositTxs + DynamicFeeTxs",
+				inners: append(generateMultipleDepositTx(r, 3), generateMultipleDynamicFeeTx(r, 3)...),
+			},
+		}
 
-	testTable := []struct {
-		name   string
-		inners []types.TxData
-	}{
-		{
-			name:   "Deposit Transaction",
-			inners: []types.TxData{depInner},
-		},
-	}
+		interfaceRegistry := codectypes.NewInterfaceRegistry()
+		rollupv1.RegisterInterfaces(interfaceRegistry)
+		protoCodec := codec.NewProtoCodec(interfaceRegistry)
 
-	for _, tc := range testTable {
-		t.Run(tc.name, func(t *testing.T) {
-			ethTxs := make([]hexutil.Bytes, len(tc.inners))
-			transactions := make([]*types.Transaction, len(tc.inners))
+		for _, tc := range testTable {
+			t.Run(tc.name, func(t *testing.T) {
+				ethTxs := make([]hexutil.Bytes, len(tc.inners))
+				transactions := make([]*ethtypes.Transaction, len(tc.inners))
 
-			for i, inner := range tc.inners {
-				transactions[i] = types.NewTx(inner)
-				txBinary, err := transactions[i].MarshalBinary()
+				depositTxsNum := 0
+				for i, inner := range tc.inners {
+					transactions[i] = ethtypes.NewTx(inner)
+					txBinary, err := transactions[i].MarshalBinary()
+					require.NoError(t, err)
+					ethTxs[i] = txBinary
+					if transactions[i].IsDepositTx() {
+						depositTxsNum++
+					}
+				}
+
+				// Convert the binary format to a Cosmos transaction.
+				cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxs)
 				require.NoError(t, err)
-				ethTxs[i] = txBinary
-			}
 
-			// Convert the binary format to a Cosmos transaction.
-			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxs)
+				if len(ethTxs) == 0 {
+					assert.Equal(t, 0, len(cosmosTxs))
+					return
+				}
+
+				var decodedTx sdktx.Tx
+				err = decodedTx.Unmarshal(cosmosTxs[0])
+				require.NoError(t, err)
+
+				var applyL1TxsRequest rollupv1.ApplyL1TxsRequest
+				err = protoCodec.Unmarshal(decodedTx.GetBody().GetMessages()[0].GetValue(), &applyL1TxsRequest)
+				require.NoError(t, err)
+
+				// Copy the original transaction because time fields are different if not copied.
+				assert.Equal(t, depositTxsNum, len(applyL1TxsRequest.TxBytes))
+				for i, txBytes := range applyL1TxsRequest.TxBytes {
+					newTransaction := transactions[i]
+					err = newTransaction.UnmarshalBinary(txBytes)
+					require.NoError(t, err)
+					assert.Equal(t, transactions[i], newTransaction)
+				}
+
+				for i := 1; i < len(cosmosTxs); i++ {
+					assert.Equal(t, transactions[depositTxsNum-1+i].Data(), []byte(cosmosTxs[i]))
+				}
+			})
+		}
+	})
+
+	t.Run("non-zero txs with error", func(t *testing.T) {
+		t.Run("unmarshal binary error", func(t *testing.T) {
+			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{[]byte("invalid")})
+			assert.Nil(t, cosmosTxs)
+			assert.ErrorContains(t, err, "unmarshal binary")
+		})
+		t.Run("zero deposit txs", func(t *testing.T) {
+			inner := generateDynamicFeeTx(r)
+			transaction := ethtypes.NewTx(inner)
+			txBytes, err := transaction.MarshalBinary()
+			require.NoError(t, err)
+			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{txBytes})
+			assert.Nil(t, cosmosTxs)
+			assert.Error(t, err)
+		})
+		t.Run("NewAnyWithValue error", func(t *testing.T) {
+			t.Skip()
+			// TODO: Implement this test case
+		})
+		t.Run("depositSDKMsgBytes marshal error", func(t *testing.T) {
+			t.Skip()
+			// TODO: Implement this test case
+		})
+		t.Run("Unpack Cosmos txs error", func(t *testing.T) {
+			depInner := generateDepositTx(r)
+			depTx := ethtypes.NewTx(depInner)
+			depTxBytes, err := depTx.MarshalBinary()
 			require.NoError(t, err)
 
-			// Unmarshal the first Cosmos transaction back into a deposit transaction.
-			for i, cosmosTx := range cosmosTxs {
-				decodedTx, err := unmarshalTx(cosmosTx)
-				require.NoError(t, err)
+			nonDepInner := generateDynamicFeeTx(r)
+			nonDepTx := ethtypes.NewTx(nonDepInner)
+			nonDepTxBytes, err := nonDepTx.MarshalBinary()
+			require.NoError(t, err)
 
-				protoCodec := makeProtoCodec()
-				var applyL1TxsRequest rollupv1.ApplyL1TxsRequest
-				err = protoCodec.Unmarshal(decodedTx.Body.Messages[0].Value, &applyL1TxsRequest)
-				require.NoError(t, err)
-
-				newTransaction := transactions[i] // Copy the original transaction because time fields are different if not copied.
-				err = newTransaction.UnmarshalBinary(applyL1TxsRequest.TxBytes[0])
-				require.NoError(t, err)
-
-				assert.Equal(t, transactions[i], newTransaction)
-			}
+			cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depTxBytes, nonDepTxBytes, []byte("invalid")})
+			assert.Nil(t, cosmosTxs)
+			assert.ErrorContains(t, err, "unmarshal binary tx: ")
 		})
+	})
+}
+
+func generateMultipleDepositTx(r *rand.Rand, n int) []ethtypes.TxData {
+	transactions := make([]ethtypes.TxData, n)
+	for i := 0; i < n; i++ {
+		transactions[i] = generateDepositTx(r)
+	}
+	return transactions
+}
+
+func generateDepositTx(r *rand.Rand) ethtypes.TxData {
+	toAddress := generateAddress(r)
+	return &ethtypes.DepositTx{
+		SourceHash:          generateHash(r),
+		From:                generateAddress(r),
+		To:                  &toAddress,
+		Value:               generateBigInt(r),
+		Gas:                 r.Uint64(),
+		Data:                generateData(r),
+		Mint:                generateBigInt(r),
+		IsSystemTransaction: false,
 	}
 }
 
-func registerInterfaces(interfaceRegistry codectypes.InterfaceRegistry) {
-	rollupv1.RegisterInterfaces(interfaceRegistry)
-}
-
-func makeProtoCodec() codec.ProtoCodecMarshaler {
-	interfaceRegistry := codectypes.NewInterfaceRegistry()
-	registerInterfaces(interfaceRegistry)
-	cdc := codec.NewProtoCodec(interfaceRegistry)
-	return cdc
-}
-
-func unmarshalTx(txBytes []byte) (*tx.Tx, error) {
-	// Initialize the codec
-	protoCodec := makeProtoCodec()
-
-	// Create a variable to hold the transaction
-	var transaction tx.Tx
-
-	// Unmarshal the transaction bytes
-	err := protoCodec.Unmarshal(txBytes, &transaction)
-	if err != nil {
-		return nil, err
+func generateMultipleDynamicFeeTx(r *rand.Rand, n int) []ethtypes.TxData {
+	transactions := make([]ethtypes.TxData, n)
+	for i := 0; i < n; i++ {
+		transactions[i] = generateDynamicFeeTx(r)
 	}
+	return transactions
+}
 
-	return &transaction, nil
+func generateDynamicFeeTx(r *rand.Rand) ethtypes.TxData {
+	toAddress := generateAddress(r)
+	return &ethtypes.DynamicFeeTx{
+		ChainID:    generateBigInt(r),
+		Nonce:      r.Uint64(),
+		GasTipCap:  generateBigInt(r),
+		GasFeeCap:  generateBigInt(r),
+		Gas:        r.Uint64(),
+		To:         &toAddress,
+		Value:      generateBigInt(r),
+		Data:       generateData(r),
+		AccessList: nil,
+		V:          generateBigInt(r),
+		R:          generateBigInt(r),
+		S:          generateBigInt(r),
+	}
+}
+
+func generateHash(r *rand.Rand) common.Hash {
+	return common.BigToHash(big.NewInt(r.Int63()))
+}
+
+func generateAddress(r *rand.Rand) common.Address {
+	return common.BigToAddress(big.NewInt(r.Int63()))
+}
+
+func generateBigInt(r *rand.Rand) *big.Int {
+	return big.NewInt(r.Int63())
+}
+
+func generateData(r *rand.Rand) []byte {
+	data := make([]byte, r.Intn(100))
+	for i := range data {
+		data[i] = byte(r.Intn(256))
+	}
+	return data
 }


### PR DESCRIPTION
Please check the current TODOs
There are some errors I can't emulate and I'm not sure this is necessary.
See TODO about AdaptCosmosTxsToEthTxs. There is an error when trying to compare the whole transaction (rollupCostData.v is different). There is a possibility that AdaptCosmosTxsToEthTxs does not work correctly. Please give me feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a comprehensive suite of unit tests to validate the conversion of Ethereum transactions to Cosmos transactions and vice versa.
	- Enhanced clarity in code with explicit package aliasing for improved readability.
	- Added new functions for converting Ethereum transactions into Cosmos transactions, improving modularity.

- **Bug Fixes**
	- Improved robustness by ensuring the adaptation functions handle erroneous inputs and edge cases effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->