### PR TITLE
Add requirements installs to `make install-buf`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ install-gofumpt:
 .PHONY: install-buf
 install-buf:
 	go install github.com/bufbuild/buf/cmd/buf@v1.31.0
+	go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@1.5.0
+	go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@1.0.0-beta.5
 
 .PHONY: install-go-test-coverage
 install-go-test-coverage:


### PR DESCRIPTION
The `install-buf` command didn't previously add all the requirements to successfully run `make gen-proto`.

PR adds installation of two protobuf plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the installation process for development tools related to the Cosmos ecosystem, improving support for protocol buffer generation.
	- Integrated new commands to install necessary plugins for a more efficient development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->