### PR TITLE
Add x/rollup withdrawal msg server

### DIFF
--- a/x/rollup/types/errors.go
+++ b/x/rollup/types/errors.go
@@ -4,15 +4,17 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 )
 
-// WrapError wraps an Cosmos-SDK error with extra message while keeping the stack trace at where this func is called.
+// WrapError wraps a Cosmos-SDK error with extra message while keeping the stack trace at where this func is called.
 var WrapError = sdkerrors.Wrapf
 
 var (
 	// error codes starting from 1
-	registerErr     = newErrRegistry(ModuleName, 1)
-	ErrInvalidL1Txs = registerErr("invalid L1 txs")
-	ErrMintETH      = registerErr("failed to mint ETH")
-	ErrL1BlockInfo  = registerErr("L1 block info")
+	registerErr      = newErrRegistry(ModuleName, 1)
+	ErrInvalidL1Txs  = registerErr("invalid L1 txs")
+	ErrMintETH       = registerErr("failed to mint ETH")
+	ErrBurnETH       = registerErr("failed to burn ETH")
+	ErrInvalidSender = registerErr("invalid sender address")
+	ErrL1BlockInfo   = registerErr("L1 block info")
 )
 
 // register new errors without hard-coding error codes

--- a/x/rollup/types/events.go
+++ b/x/rollup/types/events.go
@@ -2,15 +2,20 @@ package types
 
 const (
 	AttributeKeyL1DepositTxType   = "l1_deposit_tx_type"
+	AttributeKeyL2WithdrawalTx    = "l2_withdrawal_tx"
 	AttributeKeyBridgedTokenType  = "bridged_token_type"
 	AttributeKeyFromEvmAddress    = "from_evm_address"
 	AttributeKeyToEvmAddress      = "to_evm_address"
 	AttributeKeyFromCosmosAddress = "from_cosmos_address"
 	AttributeKeyToCosmosAddress   = "to_cosmos_address"
 	AttributeKeyAmount            = "amount"
+	AttributeKeySender            = "sender"
+	AttributeKeyL1Target          = "l1_target"
 
 	L1SystemDepositTxType = "l1_system_deposit"
 	L1UserDepositTxType   = "l1_user_deposit"
 
-	EventTypeMintETH = "mint_eth"
+	EventTypeMintETH             = "mint_eth"
+	EventTypeBurnETH             = "burn_eth"
+	EventTypeWithdrawalInitiated = "withdrawal_initiated"
 )


### PR DESCRIPTION
- Adds an `InitiateWithdrawal` msg server to the `x/rollup` module
- Burns user ETH tokens through the mint module when a withdrawal is initiated
- Some extra information is passed through the `InitiateWithdrawalRequest` message that's not currently used in the rollup module (`target`, `gas_limit`, `data`), however it will be used for processing in the monomer EVM in a subsequent PR
- Does some housekeeping in the rollup module msg server for displaying the correct error messages and passing through the correct context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for burning ETH from user accounts.
  - Added functionality for enhanced logging during the withdrawal process.
  - Expanded event handling with new types for burning ETH and initiating withdrawals.
  
- **Bug Fixes**
  - Improved error handling for invalid sender addresses during ETH transactions.
  
- **Chores**
  - Added new error codes to enhance error management related to Ethereum operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->