### PR TITLE
guard against deposit txs

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -88,7 +88,7 @@ func AdaptCosmosTxsToEthTxs(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, erro
 	txsBytes := cosmosTxs.ToSliceOfBytes()
 
 	// Unpack deposits from the MsgL1Txs msg.
-	txs, err := AdaptCosmosDepositTxToEthTx(txsBytes[0])
+	txs, err := AdaptCosmosDepositTxToEthTxs(txsBytes[0])
 	if err != nil {
 		return nil, fmt.Errorf("cosmos deposit: %v", err)
 	}
@@ -101,7 +101,7 @@ func AdaptCosmosTxsToEthTxs(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, erro
 	return txs, nil
 }
 
-func AdaptCosmosDepositTxToEthTx(cosmosEthTxBytes []byte) (ethtypes.Transactions, error) {
+func AdaptCosmosDepositTxToEthTxs(cosmosEthTxBytes []byte) (ethtypes.Transactions, error) {
 	cosmosEthTx := new(sdktx.Tx)
 	if err := cosmosEthTx.Unmarshal(cosmosEthTxBytes); err != nil {
 		return nil, fmt.Errorf("unmarshal cosmos tx: %v", err)

--- a/adapters.go
+++ b/adapters.go
@@ -122,7 +122,7 @@ func AdaptCosmosDepositTxToEthTx(cosmosEthTxBytes []byte) (ethtypes.Transactions
 	for _, txBytes := range ethTxsBytes {
 		var tx ethtypes.Transaction
 		if err := tx.UnmarshalBinary(txBytes); err != nil {
-			break
+			return nil, fmt.Errorf("unmarshal binary tx: %v", err)
 		}
 		if !tx.IsDepositTx() {
 			return nil, errors.New("MsgL1Tx contains non-deposit tx")

--- a/adapters.go
+++ b/adapters.go
@@ -90,7 +90,7 @@ func AdaptCosmosTxsToEthTxs(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, erro
 	// Unpack deposits from the MsgL1Txs msg.
 	txs, err := AdaptCosmosDepositTxToEthTx(txsBytes[0])
 	if err != nil {
-		return nil, fmt.Errorf("adapt cosmos deposit tx: %v", err)
+		return nil, fmt.Errorf("cosmos deposit: %v", err)
 	}
 
 	// Pack Cosmos txs into Ethereum txs.

--- a/adapters.go
+++ b/adapters.go
@@ -118,8 +118,8 @@ func AdaptCosmosDepositTxToEthTx(cosmosEthTxBytes []byte) (ethtypes.Transactions
 	if len(ethTxsBytes) == 0 {
 		return nil, errors.New("L1 Attributes tx not found")
 	}
-	txs := make(ethtypes.Transactions, len(ethTxsBytes))
-	for i, txBytes := range ethTxsBytes {
+	txs := make(ethtypes.Transactions, 0, len(ethTxsBytes))
+	for _, txBytes := range ethTxsBytes {
 		var tx ethtypes.Transaction
 		if err := tx.UnmarshalBinary(txBytes); err != nil {
 			break
@@ -127,7 +127,7 @@ func AdaptCosmosDepositTxToEthTx(cosmosEthTxBytes []byte) (ethtypes.Transactions
 		if !tx.IsDepositTx() {
 			return nil, errors.New("MsgL1Tx contains non-deposit tx")
 		}
-		txs[i] = &tx
+		txs = append(txs, &tx)
 	}
 
 	return txs, nil

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -55,15 +55,6 @@ func TestBuild(t *testing.T) {
 			name:          "deposit txs only",
 			depositTxsNum: 2,
 		},
-		// {
-		// 	name:             "deposit txs + non-deposit txs",
-		// 	depositTxsNum:    2,
-		// 	nonDepositTxsNum: 2,
-		// },
-		// {
-		// 	name:       "txs in mempool",
-		// 	mempoolNum: 2,
-		// },
 		{
 			name:          "deposit txs + mempool txs",
 			depositTxsNum: 2,
@@ -75,19 +66,7 @@ func TestBuild(t *testing.T) {
 			mempoolTxsNum: 2,
 			noTxPool:      true,
 		},
-		// {
-		// 	name:             "deposit txs + non-deposit txs + mempool txs",
-		// 	depositTxsNum:    2,
-		// 	nonDepositTxsNum: 2,
-		// 	mempoolTxsNum:    2,
-		// },
-		// {
-		// 	name:             "deposit txs + non-deposit txs + mempool txs with NoTxPool",
-		// 	depositTxsNum:    2,
-		// 	nonDepositTxsNum: 2,
-		// 	mempoolTxsNum:    2,
-		// 	noTxPool:         true,
-		// },
+		// TODO add test cases for non-deposit txs
 	}
 
 	for _, test := range tests {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -145,7 +145,7 @@ func TestBuild(t *testing.T) {
 				ethstatedb,
 			)
 
-			adaptedPayloadTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxsBytes)
+			adaptedPayloadTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxsBytes, nil, "")
 			require.NoError(t, err)
 
 			allTxs := slices.Clone(adaptedPayloadTxs)
@@ -278,7 +278,7 @@ func TestRollback(t *testing.T) {
 	cosmosEthTxBytes, err := cosmosEthTx.MarshalBinary()
 	require.NoError(t, err)
 
-	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes, cosmosEthTxBytes})
+	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes, cosmosEthTxBytes}, nil, "")
 	require.NoError(t, err)
 
 	block, err := b.Build(context.Background(), &builder.Payload{

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -43,25 +43,19 @@ func (*queryAll) String() string {
 }
 
 func TestBuild(t *testing.T) {
-	tests := []struct {
-		name                                           string
+	tests := map[string]struct {
 		depositTxsNum, nonDepositTxsNum, mempoolTxsNum int
 		noTxPool                                       bool
 	}{
-		{
-			name: "no txs",
-		},
-		{
-			name:          "deposit txs only",
+		"no txs": {},
+		"deposit txs only": {
 			depositTxsNum: 2,
 		},
-		{
-			name:          "deposit txs + mempool txs",
+		"deposit txs + mempool txs": {
 			depositTxsNum: 2,
 			mempoolTxsNum: 2,
 		},
-		{
-			name:          "deposit txs + mempool txs with NoTxPool",
+		"deposit txs + mempool txs with NoTxPool": {
 			depositTxsNum: 2,
 			mempoolTxsNum: 2,
 			noTxPool:      true,
@@ -69,8 +63,8 @@ func TestBuild(t *testing.T) {
 		// TODO add test cases for non-deposit txs
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
 			ethTxsBytes := make([]hexutil.Bytes, test.depositTxsNum, test.depositTxsNum+test.nonDepositTxsNum)
 			bftEthDepositTxsBytes := make(bfttypes.Txs, test.depositTxsNum)
 			mempoolTxsBytes := make([][]byte, test.mempoolTxsNum)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -280,6 +280,7 @@ func TestRollback(t *testing.T) {
 	require.NoError(t, err)
 
 	adapterTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes})
+	require.NoError(t, err)
 
 	block, err := b.Build(context.Background(), &builder.Payload{
 		Timestamp:            g.Time + 1,

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -279,12 +279,12 @@ func TestRollback(t *testing.T) {
 		MarshalBinary()
 	require.NoError(t, err)
 
-	adapterTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes})
+	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes})
 	require.NoError(t, err)
 
 	block, err := b.Build(context.Background(), &builder.Payload{
 		Timestamp:            g.Time + 1,
-		InjectedTransactions: adapterTxs,
+		InjectedTransactions: adaptedTxs,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, block)
@@ -320,7 +320,7 @@ func TestRollback(t *testing.T) {
 	require.Equal(t, ethState.GetStorageRoot(contracts.L2ApplicationStateRootProviderAddr), gethtypes.EmptyRootHash)
 
 	// Tx store.
-	for _, tx := range adapterTxs {
+	for _, tx := range adaptedTxs {
 		result, err := txStore.Get(tx.Hash())
 		require.NoError(t, err)
 		require.Nil(t, result)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/polymerdao/monomer"
+	rolluptypes "github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/txstore"
 	"github.com/polymerdao/monomer/bindings"
 	"github.com/polymerdao/monomer/builder"
@@ -26,7 +27,6 @@ import (
 	"github.com/polymerdao/monomer/mempool"
 	"github.com/polymerdao/monomer/testapp"
 	"github.com/polymerdao/monomer/testutils"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -271,15 +271,14 @@ func TestRollback(t *testing.T) {
 		ethstatedb,
 	)
 
-	rng := rand.New(rand.NewSource(1234))
+	_, depositTx, cosmosEthTx := testutils.GenerateEthTxs(t)
 
-	depositTxBytes, err := gethtypes.NewTx(
-		optestutils.GenerateDeposit(
-			optestutils.RandomHash(rng), rng)).
-		MarshalBinary()
+	depositTxBytes, err := depositTx.MarshalBinary()
+	require.NoError(t, err)
+	cosmosEthTxBytes, err := cosmosEthTx.MarshalBinary()
 	require.NoError(t, err)
 
-	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes})
+	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes, cosmosEthTxBytes})
 	require.NoError(t, err)
 
 	block, err := b.Build(context.Background(), &builder.Payload{

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -67,7 +67,7 @@ func TestBuild(t *testing.T) {
 		t.Run(description, func(t *testing.T) {
 			ethTxsBytes := make([]hexutil.Bytes, test.depositTxsNum, test.depositTxsNum+test.nonDepositTxsNum)
 			bftEthDepositTxsBytes := make(bfttypes.Txs, test.depositTxsNum)
-			mempoolTxsBytes := make([][]byte, test.mempoolTxsNum)
+			mempoolTxs := make([][]byte, test.mempoolTxsNum)
 			cosmosTxsBytes := make([]hexutil.Bytes, test.mempoolTxsNum)
 
 			rng := rand.New(rand.NewSource(1234))
@@ -99,11 +99,11 @@ func TestBuild(t *testing.T) {
 					MarshalBinary()
 				require.NoError(t, err)
 				cosmosTxsBytes[i] = hexutil.Bytes(cosmosEthTxBytes)
-				mempoolTxsBytes[i] = cosmosEthTxBytes
+				mempoolTxs[i] = cosmosEthTxBytes
 			}
 
 			pool := mempool.New(testutils.NewMemDB(t))
-			for _, tx := range mempoolTxsBytes {
+			for _, tx := range mempoolTxs {
 				require.NoError(t, pool.Enqueue(tx))
 			}
 			blockStore := testutils.NewLocalMemDB(t)
@@ -144,7 +144,7 @@ func TestBuild(t *testing.T) {
 
 			allTxs := slices.Clone(adaptedPayloadTxs)
 			if !test.noTxPool {
-				allTxs = append(allTxs, bfttypes.ToTxs(mempoolTxsBytes)...)
+				allTxs = append(allTxs, bfttypes.ToTxs(mempoolTxs)...)
 			}
 
 			payload := &builder.Payload{

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -41,8 +41,7 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) error {
 	// Attempt to adapt the Cosmos transaction to an Ethereum deposit transaction.
 	// If the adaptation results in one or more transactions, it indicates that the
 	// user transaction is a deposit transaction, which is not allowed in the pool.
-	if txs, _ := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); len(txs) > 0 {
-		// Return an error indicating that deposit transactions are not allowed in the pool.
+	if _, err := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); err == nil {
 		return errors.New("deposit txs are not allowed in the pool")
 	}
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -8,6 +8,7 @@ import (
 
 	comettypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
 const (
@@ -36,6 +37,9 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) error {
 	// NOTE: we should do reads and writes on the same view. Right now they occur on separate views.
 	// Unfortunately, comet's DB interface doesn't support it.
 	// Moving to a different DB interface is left for future work.
+	if _, err := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); err == nil {
+		return errors.New("deposit txs are not allowed in the pool")
+	}
 
 	batch := p.db.NewBatch()
 	defer batch.Close() // TODO: catch error.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -8,7 +8,7 @@ import (
 
 	comettypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
+	rolluptypes "github.com/polymerdao/monomer"
 )
 
 const (

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -37,7 +37,12 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) error {
 	// NOTE: we should do reads and writes on the same view. Right now they occur on separate views.
 	// Unfortunately, comet's DB interface doesn't support it.
 	// Moving to a different DB interface is left for future work.
+
+	// Attempt to adapt the Cosmos transaction to an Ethereum deposit transaction.
+	// If the adaptation results in one or more transactions, it indicates that the
+	// user transaction is a deposit transaction, which is not allowed in the pool.
 	if txs, _ := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); len(txs) > 0 {
+		// Return an error indicating that deposit transactions are not allowed in the pool.
 		return errors.New("deposit txs are not allowed in the pool")
 	}
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -39,7 +39,7 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) error {
 	// Moving to a different DB interface is left for future work.
 
 	// Attempt to adapt the Cosmos transaction to an Ethereum deposit transaction.
-	// If the adaptation results in one or more transactions, it indicates that the
+	// If the adaptation succeeds, it indicates that the
 	// user transaction is a deposit transaction, which is not allowed in the pool.
 	if _, err := rolluptypes.AdaptCosmosDepositTxToEthTxs(userTxn); err == nil {
 		return errors.New("deposit txs are not allowed in the pool")

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -37,7 +37,7 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) error {
 	// NOTE: we should do reads and writes on the same view. Right now they occur on separate views.
 	// Unfortunately, comet's DB interface doesn't support it.
 	// Moving to a different DB interface is left for future work.
-	if _, err := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); err == nil {
+	if txs, _ := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); len(txs) > 0 {
 		return errors.New("deposit txs are not allowed in the pool")
 	}
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -41,7 +41,7 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) error {
 	// Attempt to adapt the Cosmos transaction to an Ethereum deposit transaction.
 	// If the adaptation results in one or more transactions, it indicates that the
 	// user transaction is a deposit transaction, which is not allowed in the pool.
-	if _, err := rolluptypes.AdaptCosmosDepositTxToEthTx(userTxn); err == nil {
+	if _, err := rolluptypes.AdaptCosmosDepositTxToEthTxs(userTxn); err == nil {
 		return errors.New("deposit txs are not allowed in the pool")
 	}
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	comettypes "github.com/cometbft/cometbft/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/polymerdao/monomer/mempool"
 	"github.com/polymerdao/monomer/testutils"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +22,17 @@ func TestMempool(t *testing.T) {
 
 		_, err = pool.Dequeue()
 		require.Error(t, err)
+	})
+
+	t.Run("deposit transaction", func(t *testing.T) {
+		_, depositTx, _ := testutils.GenerateEthTxs(t)
+		depositTxBytes, err := depositTx.MarshalBinary()
+		require.NoError(t, err)
+
+		cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes})
+		require.NoError(t, err)
+
+		require.Error(t, pool.Enqueue(cosmosTxs[0]))
 	})
 
 	// enqueue multiple to empty

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -29,7 +29,7 @@ func TestMempool(t *testing.T) {
 		depositTxBytes, err := depositTx.MarshalBinary()
 		require.NoError(t, err)
 
-		cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes})
+		cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes}, nil, "")
 		require.NoError(t, err)
 
 		require.Error(t, pool.Enqueue(cosmosTxs[0]))

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -5,9 +5,9 @@ import (
 
 	comettypes "github.com/cometbft/cometbft/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	rolluptypes "github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/mempool"
 	"github.com/polymerdao/monomer/testutils"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/monomerdb/localdb/localdb_test.go
+++ b/monomerdb/localdb/localdb_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/polymerdao/monomer"
+	rolluptypes "github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/monomerdb"
 	"github.com/polymerdao/monomer/monomerdb/localdb"
 	"github.com/polymerdao/monomer/testutils"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/monomerdb/localdb/localdb_test.go
+++ b/monomerdb/localdb/localdb_test.go
@@ -28,7 +28,7 @@ func TestBlockAndHeader(t *testing.T) {
 	cosmosEthTxBytes, err := cosmosEthTx.MarshalBinary()
 	require.NoError(t, err)
 
-	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes, cosmosEthTxBytes})
+	adaptedTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{depositTxBytes, cosmosEthTxBytes}, nil, "")
 	require.NoError(t, err)
 
 	block, err := monomer.MakeBlock(&monomer.Header{}, adaptedTxs)
@@ -133,7 +133,7 @@ func TestRollback(t *testing.T) {
 		for range i + 1 {
 			hexTxs = append(hexTxs, cosmosEthTxBytes)
 		}
-		adoptedTxsCases[i], err = rolluptypes.AdaptPayloadTxsToCosmosTxs(hexTxs)
+		adoptedTxsCases[i], err = rolluptypes.AdaptPayloadTxsToCosmosTxs(hexTxs, nil, "")
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Now we prevent deposit txs from being included via the mempool, such as the BroadcastTx Comet API method. They should only be included via the Engine API.
[fixes](https://www.notion.so/nethermind/Make-sure-deposit-txs-are-not-executed-via-mempool-d09be4ccf95845948679031b42708d04?pvs=4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced transaction validation logic to prevent deposit transactions from being enqueued in the mempool.
	- Introduced a new function for adapting Cosmos deposit transactions to Ethereum transactions.

- **Bug Fixes**
	- Improved error handling and clarity when adapting transactions, ensuring better user feedback.

- **Tests**
	- Added new test cases to validate the handling of deposit transactions in the mempool.
	- Refactored tests for clearer transaction adaptation processes and improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->