### PR TITLE
Update withdrawals storage in monomer EVM

### DIFF
--- a/bindings/L2ApplicationStateRootProviderExecuter.go
+++ b/bindings/L2ApplicationStateRootProviderExecuter.go
@@ -2,6 +2,7 @@ package bindings
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/polymerdao/monomer/bindings/generated"

--- a/bindings/L2ToL1MessagePasserExecuter.go
+++ b/bindings/L2ToL1MessagePasserExecuter.go
@@ -2,12 +2,13 @@ package bindings
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	bindings "github.com/polymerdao/monomer/bindings/generated"
 	monomerevm "github.com/polymerdao/monomer/evm"
-	"math/big"
 )
 
 type L2ToL1MessagePasserExecuter struct {

--- a/bindings/L2ToL1MessagePasserExecuter.go
+++ b/bindings/L2ToL1MessagePasserExecuter.go
@@ -46,7 +46,7 @@ func (e *L2ToL1MessagePasserExecuter) InitiateWithdrawal(
 
 	senderEthAddress := common.HexToAddress(sender)
 
-	res, err := e.Call(&monomerevm.CallParams{
+	_, err = e.Call(&monomerevm.CallParams{
 		Sender: &senderEthAddress,
 		Value:  amount,
 		Data:   data,

--- a/bindings/L2ToL1MessagePasserExecuter.go
+++ b/bindings/L2ToL1MessagePasserExecuter.go
@@ -1,0 +1,50 @@
+package bindings
+
+import (
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	bindings "github.com/polymerdao/monomer/bindings/generated"
+	monomerevm "github.com/polymerdao/monomer/evm"
+	"math/big"
+)
+
+type L2ToL1MessagePasserExecuter struct {
+	*monomerevm.MonomerContractExecuter
+}
+
+func NewL2ToL1MessagePasserExecuter(evm *vm.EVM) (*L2ToL1MessagePasserExecuter, error) {
+	executer, err := monomerevm.NewMonomerContractExecuter(
+		evm,
+		bindings.L2ToL1MessagePasserMetaData.ABI,
+		predeploys.L2ToL1MessagePasserAddr,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &L2ToL1MessagePasserExecuter{executer}, nil
+}
+
+func (e *L2ToL1MessagePasserExecuter) InitiateWithdrawal(
+	sender string,
+	amount *big.Int,
+	l1Address common.Address,
+	gasLimit *big.Int,
+	data []byte,
+) error {
+	data, err := e.ABI.Pack("initiateWithdrawal", l1Address, gasLimit, data)
+	if err != nil {
+		return fmt.Errorf("create initiateWithdrawal data: %v", err)
+	}
+
+	// TODO: How should we pass through the cosmos sender address to verify that they were the one that withdrew on L2?
+	// Do we need to maintain a separate account mapping to ensure that eth msg.sender matches up instead of using the global EVM tx account?
+	// TODO: How should we ensure that the msg.value has enough funds to cover the withdrawal? Should we prepopulate an account(s) balance?
+	_, err = e.Call(data, 0)
+	if err != nil {
+		return fmt.Errorf("call initiateWithdrawal: %v", err)
+	}
+
+	return nil
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -238,7 +238,7 @@ func (b *Builder) Build(ctx context.Context, payload *Payload) (*monomer.Block, 
 
 // storeAppHashInEVM stores the updated cosmos app hash in the monomer EVM state db. This is used for proving withdrawals.
 func (b *Builder) storeAppHashInEVM(appHash []byte, ethState *state.StateDB, header *monomer.Header) error {
-	monomerEVM, err := evm.NewEVM(ethState, header, b.chainID.Big())
+	monomerEVM, err := evm.NewEVM(ethState, header)
 	if err != nil {
 		return fmt.Errorf("new EVM: %v", err)
 	}
@@ -260,7 +260,7 @@ func (b *Builder) storeWithdrawalMsgInEVM(
 	ethState *state.StateDB,
 	header *monomer.Header,
 ) error {
-	monomerEVM, err := evm.NewEVM(ethState, header, b.chainID.Big())
+	monomerEVM, err := evm.NewEVM(ethState, header)
 	if err != nil {
 		return fmt.Errorf("new EVM: %v", err)
 	}

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -3,7 +3,6 @@ package builder_test
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"testing"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
@@ -173,7 +172,7 @@ func TestBuild(t *testing.T) {
 			// Eth state db.
 			ethState, err := state.New(ethStateRoot, ethstatedb, nil)
 			require.NoError(t, err)
-			appHash, err := getAppHashFromEVM(ethState, header, chainID.Big())
+			appHash, err := getAppHashFromEVM(ethState, header)
 			require.NoError(t, err)
 			require.Equal(t, appHash[:], postBuildInfo.GetLastBlockAppHash())
 
@@ -293,8 +292,8 @@ func TestRollback(t *testing.T) {
 }
 
 // getAppHashFromEVM retrieves the updated cosmos app hash from the monomer EVM state db.
-func getAppHashFromEVM(ethState *state.StateDB, header *monomer.Header, chainID *big.Int) (common.Hash, error) {
-	monomerEVM, err := evm.NewEVM(ethState, header, chainID)
+func getAppHashFromEVM(ethState *state.StateDB, header *monomer.Header) (common.Hash, error) {
+	monomerEVM, err := evm.NewEVM(ethState, header)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("new EVM: %v", err)
 	}

--- a/contracts/predeploys.go
+++ b/contracts/predeploys.go
@@ -1,25 +1,35 @@
 package contracts
 
 import (
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	opcontracts "github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/polymerdao/monomer/bindings/generated"
 )
 
 type Predeploy struct {
-	Address          common.Address
-	DeployedBytecode []byte
+	address          common.Address
+	deployedBytecode []byte
 }
 
 var L2ApplicationStateRootProviderAddr = common.HexToAddress("0x4300000000000000000000000000000000000001")
 
-var Predeploys = []*Predeploy{
+var predeploys = []*Predeploy{
 	{
-		Address:          L2ApplicationStateRootProviderAddr,
-		DeployedBytecode: common.FromHex(bindings.L2ApplicationStateRootProviderMetaData.Bin),
+		address:          L2ApplicationStateRootProviderAddr,
+		deployedBytecode: common.FromHex(bindings.L2ApplicationStateRootProviderMetaData.Bin),
 	},
 	{
-		Address:          predeploys.L2ToL1MessagePasserAddr,
-		DeployedBytecode: common.FromHex(bindings.L2ToL1MessagePasserMetaData.Bin),
+		address:          opcontracts.L2ToL1MessagePasserAddr,
+		deployedBytecode: common.FromHex(bindings.L2ToL1MessagePasserMetaData.Bin),
 	},
+}
+
+func PredeployContracts(ethState *state.StateDB) *state.StateDB {
+	// TODO: investigate using the foundry deploy system for setting up the eth genesis state
+	// see https://github.com/polymerdao/monomer/pull/84#discussion_r1697579464
+	for _, predeploy := range predeploys {
+		ethState.SetCode(predeploy.address, predeploy.deployedBytecode)
+	}
+	return ethState
 }

--- a/contracts/predeploys.go
+++ b/contracts/predeploys.go
@@ -7,14 +7,14 @@ import (
 	"github.com/polymerdao/monomer/bindings/generated"
 )
 
-type Predeploy struct {
+type predeploy struct {
 	address          common.Address
 	deployedBytecode []byte
 }
 
 var L2ApplicationStateRootProviderAddr = common.HexToAddress("0x4300000000000000000000000000000000000001")
 
-var predeploys = []*Predeploy{
+var predeploys = []*predeploy{
 	{
 		address:          L2ApplicationStateRootProviderAddr,
 		deployedBytecode: common.FromHex(bindings.L2ApplicationStateRootProviderMetaData.Bin),
@@ -25,7 +25,7 @@ var predeploys = []*Predeploy{
 	},
 }
 
-func PredeployContracts(ethState *state.StateDB) *state.StateDB {
+func Predeploy(ethState *state.StateDB) *state.StateDB {
 	// TODO: investigate using the foundry deploy system for setting up the eth genesis state
 	// see https://github.com/polymerdao/monomer/pull/84#discussion_r1697579464
 	for _, predeploy := range predeploys {

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"github.com/holiman/uint256"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -21,9 +22,9 @@ var (
 	MonomerEVMTxOriginAddress = common.HexToAddress("0x4300000000000000000000000000000000000000")
 )
 
-func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.EVM, error) {
+func NewEVM(ethState vm.StateDB, header *monomer.Header) (*vm.EVM, error) {
 	chainConfig := &params.ChainConfig{
-		ChainID: chainID,
+		ChainID: header.ChainID.Big(),
 
 		ByzantiumBlock:      new(big.Int),
 		ConstantinopleBlock: new(big.Int),
@@ -44,6 +45,7 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.
 	blockContext := core.NewEVMBlockContext(header.ToEth(), mockChainContext{}, &MonomerEVMTxOriginAddress, chainConfig, ethState)
 	// TODO: investigate having an unlimited gas limit for monomer EVM execution
 	blockContext.GasLimit = 100_000_000
+	blockContext.CanTransfer = CanTransfer
 
 	return vm.NewEVM(
 		blockContext,
@@ -57,6 +59,11 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.
 			NoBaseFee: true,
 		},
 	), nil
+}
+
+// CanTransfer is overridden to explicilty allow all transfers in the monomer EVM. This avoids needing to deal with account balances.
+func CanTransfer(db vm.StateDB, addr common.Address, amount *uint256.Int) bool {
+	return true
 }
 
 type mockChainContext struct{}

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -1,7 +1,6 @@
 package evm
 
 import (
-	"github.com/holiman/uint256"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -11,6 +10,7 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/utils"
 )
@@ -61,7 +61,7 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header) (*vm.EVM, error) {
 	), nil
 }
 
-// CanTransfer is overridden to explicilty allow all transfers in the monomer EVM. This avoids needing to deal with account balances.
+// CanTransfer is overridden to explicitly allow all transfers in the monomer EVM. This avoids needing to deal with account balances.
 func CanTransfer(db vm.StateDB, addr common.Address, amount *uint256.Int) bool {
 	return true
 }

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -17,7 +17,7 @@ import (
 var (
 	// MonomerGenesisRootHash is the known root hash of the monomer ethereum state trie after all predeployed contracts are created.
 	MonomerGenesisRootHash = common.HexToHash("0x5be0a68aae2d389cd9c9276ece59f483b97da7e99d2ff157923f4822dc107b6b")
-	// MonomerEVMTxOriginAddress is the address used for executing transactions in the monomer evm.
+	// MonomerEVMTxOriginAddress is the address used for executing transactions in the monomer EVM.
 	MonomerEVMTxOriginAddress = common.HexToAddress("0x4300000000000000000000000000000000000000")
 )
 
@@ -30,7 +30,7 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.
 		PetersburgBlock:     new(big.Int),
 		IstanbulBlock:       new(big.Int),
 		MuirGlacierBlock:    new(big.Int),
-		// TODO: investigate SSTORE access list evm execution bug with BerlinBlock/LondonBlock
+		// TODO: investigate SSTORE access list EVM execution bug with BerlinBlock/LondonBlock
 		// BerlinBlock:        new(big.Int),
 		// LondonBlock:        new(big.Int),
 		ArrowGlacierBlock:  new(big.Int),
@@ -42,7 +42,7 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.
 		CanyonTime:   utils.Ptr(uint64(0)),
 	}
 	blockContext := core.NewEVMBlockContext(header.ToEth(), mockChainContext{}, &MonomerEVMTxOriginAddress, chainConfig, ethState)
-	// TODO: investigate having an unlimited gas limit for monomer evm execution
+	// TODO: investigate having an unlimited gas limit for monomer EVM execution
 	blockContext.GasLimit = 100_000_000
 
 	return vm.NewEVM(

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -17,7 +17,7 @@ import (
 var (
 	// MonomerGenesisRootHash is the known root hash of the monomer ethereum state trie after all predeployed contracts are created.
 	MonomerGenesisRootHash = common.HexToHash("0x5be0a68aae2d389cd9c9276ece59f483b97da7e99d2ff157923f4822dc107b6b")
-	// MonomerEVMTxOriginAddress is the address used for executing transactions in the monomer EVM.
+	// MonomerEVMTxOriginAddress is the address used for executing transactions in the monomer evm.
 	MonomerEVMTxOriginAddress = common.HexToAddress("0x4300000000000000000000000000000000000000")
 )
 
@@ -30,7 +30,7 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.
 		PetersburgBlock:     new(big.Int),
 		IstanbulBlock:       new(big.Int),
 		MuirGlacierBlock:    new(big.Int),
-		// TODO: investigate SSTORE access list EVM execution bug with BerlinBlock/LondonBlock
+		// TODO: investigate SSTORE access list evm execution bug with BerlinBlock/LondonBlock
 		// BerlinBlock:        new(big.Int),
 		// LondonBlock:        new(big.Int),
 		ArrowGlacierBlock:  new(big.Int),
@@ -42,7 +42,7 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header, chainID *big.Int) (*vm.
 		CanyonTime:   utils.Ptr(uint64(0)),
 	}
 	blockContext := core.NewEVMBlockContext(header.ToEth(), mockChainContext{}, &MonomerEVMTxOriginAddress, chainConfig, ethState)
-	// TODO: investigate having an unlimited gas limit for monomer EVM execution
+	// TODO: investigate having an unlimited gas limit for monomer evm execution
 	blockContext.GasLimit = 100_000_000
 
 	return vm.NewEVM(

--- a/evm/executer.go
+++ b/evm/executer.go
@@ -1,0 +1,44 @@
+package evm
+
+import (
+	"fmt"
+	"strings"
+
+	gethabi "github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+)
+
+type MonomerContractExecuter struct {
+	ABI          *gethabi.ABI
+	evm          *vm.EVM
+	contractAddr common.Address
+}
+
+func NewMonomerContractExecuter(evm *vm.EVM, abiJSON string, contractAddr common.Address) (*MonomerContractExecuter, error) {
+	abi, err := gethabi.JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		return nil, err
+	}
+	return &MonomerContractExecuter{
+		ABI:          &abi,
+		evm:          evm,
+		contractAddr: contractAddr,
+	}, nil
+}
+
+// TODO: use a call struct param to specify the call specific call params or revert to a default if nil
+func (e *MonomerContractExecuter) Call(data []byte, value uint64) ([]byte, error) {
+	res, _, err := e.evm.Call(
+		vm.AccountRef(e.evm.TxContext.Origin),
+		e.contractAddr,
+		data,
+		e.evm.Context.GasLimit,
+		uint256.NewInt(value),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("call contract %v: %v", e.contractAddr, err)
+	}
+	return res, nil
+}

--- a/evm/executer_test.go
+++ b/evm/executer_test.go
@@ -1,10 +1,10 @@
 package evm_test
 
 import (
-	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/evm/executer_test.go
+++ b/evm/executer_test.go
@@ -1,0 +1,88 @@
+package evm_test
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/polymerdao/monomer"
+	"github.com/polymerdao/monomer/bindings"
+	"github.com/polymerdao/monomer/contracts"
+	"github.com/polymerdao/monomer/evm"
+	"github.com/polymerdao/monomer/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestL2ApplicationStateRootProviderExecuter(t *testing.T) {
+	executer, err := bindings.NewL2ApplicationStateRootProviderExecuter(setupEVM(t))
+	require.NoError(t, err)
+
+	// Get the initial state root
+	emptyStateRoot, err := executer.GetL2ApplicationStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, common.Hash{}, emptyStateRoot)
+
+	// Update the state root
+	newStateRoot := common.HexToHash("0x01")
+	err = executer.SetL2ApplicationStateRoot(newStateRoot)
+	require.NoError(t, err)
+
+	// Get the updated state root
+	gotStateRoot, err := executer.GetL2ApplicationStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, newStateRoot, gotStateRoot)
+}
+
+func TestL2ToL1MessagePasserExecuter(t *testing.T) {
+	executer, err := bindings.NewL2ToL1MessagePasserExecuter(setupEVM(t))
+	require.NoError(t, err)
+
+	cosmosSenderAddr := "cosmosAddr"
+	ethSenderAddr := common.HexToAddress(cosmosSenderAddr)
+	amount := big.NewInt(500)
+	l1TargetAddress := common.HexToAddress("0x12345abcdef")
+	gasLimit := big.NewInt(100_000)
+	data := []byte("data")
+
+	withdrawalHash, err := crossdomain.NewWithdrawal(
+		big.NewInt(1), // expected nonce
+		&ethSenderAddr,
+		&l1TargetAddress,
+		amount,
+		gasLimit,
+		data,
+	).Hash()
+	require.NoError(t, err)
+
+	// Check that the withdrawal hash is not in the sentMessages mapping
+	sentMessagesMappingValue, err := executer.GetSentMessagesMappingValue(withdrawalHash)
+	require.NoError(t, err)
+	require.False(t, sentMessagesMappingValue)
+
+	// Initiate a withdrawal
+	err = executer.InitiateWithdrawal(cosmosSenderAddr, amount, l1TargetAddress, gasLimit, data)
+	require.NoError(t, err)
+
+	// Check that the withdrawal hash is in the sentMessages mapping
+	sentMessagesMappingValue, err = executer.GetSentMessagesMappingValue(withdrawalHash)
+	require.NoError(t, err)
+	require.True(t, sentMessagesMappingValue)
+}
+
+func setupEVM(t *testing.T) *vm.EVM {
+	ethState, err := state.New(types.EmptyRootHash, testutils.NewEthStateDB(t), nil)
+	require.NoError(t, err)
+	monomerEVM, err := evm.NewEVM(
+		contracts.PredeployContracts(ethState),
+		&monomer.Header{
+			ChainID: monomer.ChainID(1),
+			Height:  1,
+		},
+	)
+	require.NoError(t, err)
+	return monomerEVM
+}

--- a/evm/executer_test.go
+++ b/evm/executer_test.go
@@ -49,7 +49,7 @@ func TestL2ToL1MessagePasserExecuter(t *testing.T) {
 	data := []byte("data")
 
 	withdrawalHash, err := crossdomain.NewWithdrawal(
-		big.NewInt(1), // expected nonce
+		crossdomain.EncodeVersionedNonce(big.NewInt(0), big.NewInt(1)),
 		&ethSenderAddr,
 		&l1TargetAddress,
 		amount,

--- a/evm/executer_test.go
+++ b/evm/executer_test.go
@@ -77,7 +77,7 @@ func setupEVM(t *testing.T) *vm.EVM {
 	ethState, err := state.New(types.EmptyRootHash, testutils.NewEthStateDB(t), nil)
 	require.NoError(t, err)
 	monomerEVM, err := evm.NewEVM(
-		contracts.PredeployContracts(ethState),
+		contracts.Predeploy(ethState),
 		&monomer.Header{
 			ChainID: monomer.ChainID(1),
 			Height:  1,

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -75,7 +75,7 @@ func (g *Genesis) Commit(ctx context.Context, app monomer.Application, blockStor
 	if err != nil {
 		return fmt.Errorf("create ethereum state: %v", err)
 	}
-	ethStateRoot, err := contracts.PredeployContracts(ethState).Commit(initialHeight, true)
+	ethStateRoot, err := contracts.Predeploy(ethState).Commit(initialHeight, true)
 	if err != nil {
 		return fmt.Errorf("commit ethereum genesis state: %v", err)
 	}

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/polymerdao/monomer/contracts"
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -13,7 +14,6 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
-	"github.com/polymerdao/monomer/contracts"
 )
 
 type Genesis struct {
@@ -75,7 +75,7 @@ func (g *Genesis) Commit(ctx context.Context, app monomer.Application, blockStor
 	if err != nil {
 		return fmt.Errorf("create ethereum state: %v", err)
 	}
-	ethStateRoot, err := g.predeployContracts(ethState).Commit(initialHeight, true)
+	ethStateRoot, err := contracts.PredeployContracts(ethState).Commit(initialHeight, true)
 	if err != nil {
 		return fmt.Errorf("commit ethereum genesis state: %v", err)
 	}
@@ -94,13 +94,4 @@ func (g *Genesis) Commit(ctx context.Context, app monomer.Application, blockStor
 		}
 	}
 	return nil
-}
-
-func (g *Genesis) predeployContracts(ethState *state.StateDB) *state.StateDB {
-	// TODO: investigate using the foundry deploy system for setting up the eth genesis state
-	// see https://github.com/polymerdao/monomer/pull/84#discussion_r1697579464
-	for _, predeploy := range contracts.Predeploys {
-		ethState.SetCode(predeploy.Address, predeploy.DeployedBytecode)
-	}
-	return ethState
 }

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/polymerdao/monomer/contracts"
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -14,6 +13,7 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/app/peptide/store"
+	"github.com/polymerdao/monomer/contracts"
 )
 
 type Genesis struct {


### PR DESCRIPTION
- After an application block is finalized, all withdrawal transactions are also passed through to the `L2ToL1MessagePasser` contract in the Monomer EVM. The hash of each withdrawal tx is stored in the contract and is used to prove to L1 that the withdrawal took place on L2.
- Unit tests were added to verify the correct storage behavior of the monomer EVM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for initiating withdrawals and checking sent messages between Layer 2 and Layer 1.
	- Added a new `MonomerContractExecuter` for simplified smart contract interactions.
	- Created a `PredeployContracts` function to enhance contract deployment into Ethereum state.

- **Bug Fixes**
	- Improved handling and validation of transaction results during withdrawal processing.

- **Refactor**
	- Streamlined code structure and naming conventions across several modules for better clarity and maintainability.

- **Tests**
	- Implemented unit tests for new functionalities, ensuring correct behavior of state management and message passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->