### PR TITLE
Fix `make install-buf`...

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           go-version-file: go.mod
       - run: make test
 
-  devrequirments:
+  devrequirements:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,15 @@ jobs:
           go-version-file: go.mod
       - run: make test
 
+  devrequirments:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make install-buf
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ install-gofumpt:
 .PHONY: install-buf
 install-buf:
 	go install github.com/bufbuild/buf/cmd/buf@v1.31.0
-	go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@1.5.0
-	go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@1.0.0-beta.5
+	go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@v1.5.0
+	go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@v1.0.0-beta.5
 
 .PHONY: install-go-test-coverage
 install-go-test-coverage:


### PR DESCRIPTION
Prior change had incorrect version tag strings: `@1.5.0` instead of `@v1.5.0`.

PR staged:
1. [x] add a CI test to flag when `make install-buf` fails https://github.com/polymerdao/monomer/pull/92/commits/b2f8a220e4308ee30de4d72c34b6b6c2447e83dd
2. [x] add a fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new job named `devrequirments` in the CI/CD pipeline to streamline the installation of development dependencies on macOS.

This enhancement improves the overall development workflow, making it easier for contributors to set up their environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->