### PR TITLE
Pass cosmos-sdk client.Context to engine

### DIFF
--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -247,6 +247,7 @@ func (s *Stack) runMonomer(ctx context.Context, env *environment.Env, genesisTim
 	env.DeferErr("close eth state db", ethstatedb.Close)
 	n := node.New(
 		app,
+		nil,
 		&genesis.Genesis{
 			AppState: app.DefaultGenesis(),
 			ChainID:  chainID,

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -312,12 +312,15 @@ type mockAccount struct {
 func (mar mockAccount) GetAddress() sdktypes.AccAddress {
 	return mar.address
 }
+
 func (mar mockAccount) GetPubKey() cryptotypes.PubKey {
 	return nil
 }
+
 func (mar mockAccount) GetAccountNumber() uint64 {
 	return 1
 }
+
 func (mar mockAccount) GetSequence() uint64 {
 	mar.seqNumber++
 	return mar.seqNumber

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -178,7 +178,7 @@ func (e *EngineAPI) ForkchoiceUpdatedV3(
 		return nil, engine.InvalidPayloadAttributes.With(errors.New("gas limit not provided"))
 	}
 
-	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(pa.Transactions)
+	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(pa.Transactions, *e.appChainClient)
 	if err != nil {
 		return nil, engine.InvalidPayloadAttributes.With(fmt.Errorf("convert payload attributes txs to cosmos txs: %v", err))
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -178,7 +178,7 @@ func (e *EngineAPI) ForkchoiceUpdatedV3(
 		return nil, engine.InvalidPayloadAttributes.With(errors.New("gas limit not provided"))
 	}
 
-	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(pa.Transactions, e.signer)
+	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(pa.Transactions, e.sign)
 	if err != nil {
 		return nil, engine.InvalidPayloadAttributes.With(fmt.Errorf("convert payload attributes txs to cosmos txs: %v", err))
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -178,7 +178,7 @@ func (e *EngineAPI) ForkchoiceUpdatedV3(
 		return nil, engine.InvalidPayloadAttributes.With(errors.New("gas limit not provided"))
 	}
 
-	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(pa.Transactions, *e.appChainClient)
+	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(pa.Transactions, e.signer)
 	if err != nil {
 		return nil, engine.InvalidPayloadAttributes.With(fmt.Errorf("convert payload attributes txs to cosmos txs: %v", err))
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -31,6 +32,7 @@ type EngineAPI struct {
 	builder                  *builder.Builder
 	txValidator              TxValidator
 	blockStore               DB
+	appChainClient           *client.Context
 	currentPayloadAttributes *monomer.PayloadAttributes
 	metrics                  Metrics
 	lock                     sync.RWMutex
@@ -44,13 +46,15 @@ func NewEngineAPI(
 	b *builder.Builder,
 	txValidator TxValidator,
 	blockStore DB,
+	appChainClient *client.Context,
 	metrics Metrics,
 ) *EngineAPI {
 	return &EngineAPI{
-		txValidator: txValidator,
-		blockStore:  blockStore,
-		builder:     b,
-		metrics:     metrics,
+		txValidator:    txValidator,
+		appChainClient: appChainClient,
+		blockStore:     blockStore,
+		builder:        b,
+		metrics:        metrics,
 	}
 }
 

--- a/engine/signer.go
+++ b/engine/signer.go
@@ -1,0 +1,102 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	cosmostx "github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+)
+
+func (e *EngineAPI) signer(tx *sdktx.Tx) error {
+
+	// return func(tx *sdktx.Tx) error {
+
+	privKey := ed25519.GenPrivKeyFromSecret([]byte("monomer"))
+	pubKey := privKey.PubKey()
+	address := pubKey.Address()
+
+	txConfig := e.appChainClient.TxConfig
+	txBuilder := txConfig.NewTxBuilder()
+
+	acc, err := e.appChainClient.AccountRetriever.GetAccount(*e.appChainClient, sdktypes.AccAddress(address.Bytes()))
+
+	if err != nil {
+		return fmt.Errorf("get account: %v", err)
+	}
+
+	signerData := authsigning.SignerData{
+		ChainID:       e.appChainClient.ChainID,
+		AccountNumber: acc.GetAccountNumber(),
+		Sequence:      acc.GetSequence(),
+		PubKey:        pubKey,
+		Address:       acc.GetAddress().String(),
+	}
+
+	blankSig := signing.SignatureV2{
+		PubKey:   pubKey,
+		Sequence: acc.GetSequence(),
+		Data: &signing.SingleSignatureData{
+			SignMode:  signing.SignMode_SIGN_MODE_DIRECT,
+			Signature: nil,
+		},
+	}
+
+	err = txBuilder.SetMsgs(tx.Body.Messages[0])
+
+	if err != nil {
+		return fmt.Errorf("set msgs: %v", err)
+	}
+	err = txBuilder.SetSignatures(blankSig)
+	if err != nil {
+		return fmt.Errorf("set signatures: %v", err)
+	}
+
+	sig, err := cosmostx.SignWithPrivKey(
+		context.Background(),
+		signing.SignMode_SIGN_MODE_DIRECT,
+		signerData,
+		txBuilder,
+		privKey,
+		txConfig,
+		acc.GetSequence(),
+	)
+	if err != nil {
+		return fmt.Errorf("sign with priv key: %v", err)
+	}
+	err = txBuilder.SetSignatures(sig)
+	if err != nil {
+		return fmt.Errorf("set signatures: %v", err)
+	}
+
+	pubKeyAny, err := codectypes.NewAnyWithValue(pubKey)
+	if err != nil {
+		return fmt.Errorf("new any with value: %v", err)
+	}
+
+	tx.AuthInfo = &sdktx.AuthInfo{
+		SignerInfos: []*sdktx.SignerInfo{
+			{
+				PublicKey: pubKeyAny,
+				ModeInfo: &sdktx.ModeInfo{
+					// Assuming you want single signer mode
+					Sum: &sdktx.ModeInfo_Single_{
+						Single: &sdktx.ModeInfo_Single{
+							Mode: signing.SignMode_SIGN_MODE_DIRECT,
+						},
+					},
+				},
+				Sequence: acc.GetSequence(),
+			},
+		},
+	}
+	tx.Signatures = [][]byte{sig.Data.(*signing.SingleSignatureData).Signature}
+
+	return nil
+	// }
+}

--- a/engine/signer.go
+++ b/engine/signer.go
@@ -14,9 +14,6 @@ import (
 )
 
 func (e *EngineAPI) signer(tx *sdktx.Tx) error {
-
-	// return func(tx *sdktx.Tx) error {
-
 	privKey := ed25519.GenPrivKeyFromSecret([]byte("monomer"))
 	pubKey := privKey.PubKey()
 	address := pubKey.Address()
@@ -25,7 +22,6 @@ func (e *EngineAPI) signer(tx *sdktx.Tx) error {
 	txBuilder := txConfig.NewTxBuilder()
 
 	acc, err := e.appChainClient.AccountRetriever.GetAccount(*e.appChainClient, sdktypes.AccAddress(address.Bytes()))
-
 	if err != nil {
 		return fmt.Errorf("get account: %v", err)
 	}
@@ -48,7 +44,6 @@ func (e *EngineAPI) signer(tx *sdktx.Tx) error {
 	}
 
 	err = txBuilder.SetMsgs(tx.Body.Messages[0])
-
 	if err != nil {
 		return fmt.Errorf("set msgs: %v", err)
 	}

--- a/engine/signer.go
+++ b/engine/signer.go
@@ -13,7 +13,13 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
 
-func (e *EngineAPI) signer(tx *sdktx.Tx) error {
+func (e *EngineAPI) sign(tx *sdktx.Tx) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic during tx signing: %v", r)
+		}
+	}()
+
 	privKey := ed25519.GenPrivKeyFromSecret([]byte("monomer"))
 	pubKey := privKey.PubKey()
 	address := pubKey.Address()
@@ -93,5 +99,4 @@ func (e *EngineAPI) signer(tx *sdktx.Tx) error {
 	tx.Signatures = [][]byte{sig.Data.(*signing.SingleSignatureData).Signature}
 
 	return nil
-	// }
 }

--- a/integrations/integrations.go
+++ b/integrations/integrations.go
@@ -132,7 +132,7 @@ func startInProcess(
 	svrCtx.Logger.Info("Starting Monomer node in-process")
 	err := startMonomerNode(&WrappedApplication{
 		app: app,
-	}, env, monomerCtx, svrCtx)
+	}, env, monomerCtx, svrCtx, clientCtx)
 	if err != nil {
 		return fmt.Errorf("start Monomer node: %v", err)
 	}
@@ -157,6 +157,7 @@ func startMonomerNode(
 	env *environment.Env,
 	monomerCtx context.Context,
 	svrCtx *server.Context,
+	clientCtx *client.Context,
 ) error {
 	engineWS, err := net.Listen("tcp", viper.GetString(monomerEngineWSFlag))
 	if err != nil {
@@ -230,6 +231,7 @@ func startMonomerNode(
 
 	n := node.New(
 		wrappedApp,
+		clientCtx,
 		&genesis.Genesis{
 			ChainID:  monomer.ChainID(genChainID),
 			AppState: appState,

--- a/node/node.go
+++ b/node/node.go
@@ -58,7 +58,7 @@ type DB interface {
 
 type Node struct {
 	app            monomer.Application
-	client         *client.Context
+	appchainCtx    *client.Context
 	genesis        *genesis.Genesis
 	engineWS       net.Listener
 	cometHTTPAndWS net.Listener
@@ -72,7 +72,7 @@ type Node struct {
 
 func New(
 	app monomer.Application,
-	client *client.Context,
+	appchainCtx *client.Context,
 	g *genesis.Genesis,
 	engineWS net.Listener,
 	cometHTTPAndWS net.Listener,
@@ -85,7 +85,7 @@ func New(
 ) *Node {
 	return &Node{
 		app:            app,
-		client:         client,
+		appchainCtx:    appchainCtx,
 		genesis:        g,
 		engineWS:       engineWS,
 		cometHTTPAndWS: cometHTTPAndWS,
@@ -125,7 +125,7 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 				builder.New(mpool, n.app, n.blockdb, txStore, eventBus, n.genesis.ChainID, n.ethstatedb),
 				n.app,
 				n.blockdb,
-				n.client,
+				n.appchainCtx,
 				engineMetrics,
 			),
 		},

--- a/node/node.go
+++ b/node/node.go
@@ -125,6 +125,7 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 				builder.New(mpool, n.app, n.blockdb, txStore, eventBus, n.genesis.ChainID, n.ethstatedb),
 				n.app,
 				n.blockdb,
+				n.client,
 				engineMetrics,
 			),
 		},

--- a/node/node.go
+++ b/node/node.go
@@ -16,6 +16,7 @@ import (
 	jsonrpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	bfttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/client"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -57,6 +58,7 @@ type DB interface {
 
 type Node struct {
 	app            monomer.Application
+	client         *client.Context
 	genesis        *genesis.Genesis
 	engineWS       net.Listener
 	cometHTTPAndWS net.Listener
@@ -70,6 +72,7 @@ type Node struct {
 
 func New(
 	app monomer.Application,
+	client *client.Context,
 	g *genesis.Genesis,
 	engineWS net.Listener,
 	cometHTTPAndWS net.Listener,
@@ -82,6 +85,7 @@ func New(
 ) *Node {
 	return &Node{
 		app:            app,
+		client:         client,
 		genesis:        g,
 		engineWS:       engineWS,
 		cometHTTPAndWS: cometHTTPAndWS,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -40,6 +40,7 @@ func TestRun(t *testing.T) {
 	}()
 	n := node.New(
 		app,
+		nil,
 		&genesis.Genesis{
 			ChainID:  chainID,
 			AppState: testapp.MakeGenesisAppState(t, app),

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -98,7 +98,7 @@ func GenerateBlockFromEthTxs(t *testing.T, l1InfoTx *gethtypes.Transaction, depo
 		require.NoError(t, err)
 		ethTxBytes = append(ethTxBytes, cosmosEthTxBytes)
 	}
-	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxBytes)
+	cosmosTxs, err := rolluptypes.AdaptPayloadTxsToCosmosTxs(ethTxBytes, nil)
 	require.NoError(t, err)
 	block, err := monomer.MakeBlock(&monomer.Header{}, cosmosTxs)
 	require.NoError(t, err)

--- a/x/rollup/types/adapters.go
+++ b/x/rollup/types/adapters.go
@@ -1,15 +1,23 @@
 package types
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"runtime"
 
 	bfttypes "github.com/cometbft/cometbft/types"
+	cosmosclient "github.com/cosmos/cosmos-sdk/client"
+	cosmostx "github.com/cosmos/cosmos-sdk/client/tx"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/polymerdao/monomer/gen/rollup/v1"
+	rollupv1 "github.com/polymerdao/monomer/gen/rollup/v1"
 )
 
 var errL1AttributesNotFound = errors.New("L1 attributes tx not found")
@@ -48,11 +56,93 @@ func AdaptPayloadTxsToCosmosTxs(ethTxs []hexutil.Bytes, appchainCtx cosmosclient
 	if err != nil {
 		return nil, fmt.Errorf("new any with value: %v", err)
 	}
-	depositSDKMsgBytes, err := (&sdktx.Tx{
+	depositTx := sdktx.Tx{
 		Body: &sdktx.TxBody{
 			Messages: []*codectypes.Any{msgAny},
 		},
-	}).Marshal()
+	}
+
+	privKey := ed25519.GenPrivKeyFromSecret([]byte("monomer"))
+	pubKey := privKey.PubKey()
+	address := pubKey.Address()
+
+	txConfig := appchainCtx.TxConfig
+	txBuilder := txConfig.NewTxBuilder()
+
+	acc, err := appchainCtx.AccountRetriever.GetAccount(appchainCtx, sdktypes.AccAddress(address.Bytes()))
+
+	if err != nil {
+		return nil, fmt.Errorf("get account: %v", err)
+	}
+
+	signerData := authsigning.SignerData{
+		ChainID:       appchainCtx.ChainID,
+		AccountNumber: acc.GetAccountNumber(),
+		Sequence:      acc.GetSequence(),
+		PubKey:        pubKey,
+		Address:       acc.GetAddress().String(),
+	}
+
+	blankSig := signing.SignatureV2{
+		PubKey:   pubKey,
+		Sequence: acc.GetSequence(),
+		Data: &signing.SingleSignatureData{
+			SignMode:  signing.SignMode_SIGN_MODE_DIRECT,
+			Signature: nil,
+		},
+	}
+
+	err = txBuilder.SetMsgs(msgAny)
+	if err != nil {
+		return nil, fmt.Errorf("set msgs: %v", err)
+	}
+	err = txBuilder.SetSignatures(blankSig)
+	if err != nil {
+		return nil, fmt.Errorf("set signatures: %v", err)
+	}
+
+	sig, err := cosmostx.SignWithPrivKey(
+		context.Background(),
+		signing.SignMode_SIGN_MODE_DIRECT,
+		signerData,
+		txBuilder,
+		privKey,
+		txConfig,
+		acc.GetSequence(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign with priv key: %v", err)
+	}
+	err = txBuilder.SetSignatures(sig)
+	if err != nil {
+		return nil, fmt.Errorf("set signatures: %v", err)
+	}
+	// tx := txBuilder.GetTx()
+
+	pubKeyAny, err := codectypes.NewAnyWithValue(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("new any with value: %v", err)
+	}
+
+	depositTx.AuthInfo = &sdktx.AuthInfo{
+		SignerInfos: []*sdktx.SignerInfo{
+			{
+				PublicKey: pubKeyAny,
+				ModeInfo: &sdktx.ModeInfo{
+					// Assuming you want single signer mode
+					Sum: &sdktx.ModeInfo_Single_{
+						Single: &sdktx.ModeInfo_Single{
+							Mode: signing.SignMode_SIGN_MODE_DIRECT,
+						},
+					},
+				},
+				Sequence: acc.GetSequence(),
+			},
+		},
+	}
+	depositTx.Signatures = [][]byte{sig.Data.(*signing.SingleSignatureData).Signature}
+
+	depositSDKMsgBytes, err := depositTx.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshal tx: %v", err)
 	}

--- a/x/rollup/types/adapters.go
+++ b/x/rollup/types/adapters.go
@@ -3,7 +3,6 @@ package types
 import (
 	"errors"
 	"fmt"
-	"runtime"
 
 	bfttypes "github.com/cometbft/cometbft/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -19,22 +18,6 @@ type txSigner func(tx *sdktx.Tx) error
 
 // AdaptPayloadTxsToCosmosTxs assumes the deposit transactions come first.
 func AdaptPayloadTxsToCosmosTxs(ethTxs []hexutil.Bytes, signTx txSigner) (bfttypes.Txs, error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// Get the stack trace
-			stackTrace := make([]byte, 4096)
-			stackSize := runtime.Stack(stackTrace, false)
-
-			// Extract file and line information
-			_, file, line, ok := runtime.Caller(2)
-			if ok {
-				fmt.Printf("Panic occurred in file %s at line %d\n", file, line)
-			}
-
-			fmt.Printf("Stack Trace:\n%s\n", stackTrace[:stackSize])
-		}
-	}()
-
 	if len(ethTxs) == 0 {
 		return bfttypes.Txs{}, nil
 	}

--- a/x/rollup/types/adapters.go
+++ b/x/rollup/types/adapters.go
@@ -15,7 +15,7 @@ import (
 var errL1AttributesNotFound = errors.New("L1 attributes tx not found")
 
 // AdaptPayloadTxsToCosmosTxs assumes the deposit transactions come first.
-func AdaptPayloadTxsToCosmosTxs(ethTxs []hexutil.Bytes) (bfttypes.Txs, error) {
+func AdaptPayloadTxsToCosmosTxs(ethTxs []hexutil.Bytes, appchainCtx cosmosclient.Context) (bfttypes.Txs, error) {
 	if len(ethTxs) == 0 {
 		return bfttypes.Txs{}, nil
 	}


### PR DESCRIPTION
This struct provides access the required contextual data for the engine to sign deposit transactions.

Checkpointing this small PR in case there's a good reason
- not to pass it
- to pass via a restricted interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the EngineAPI to manage application-specific chain interactions through the addition of a new client context.
  - Improved the runMonomer functionality to facilitate operations that depend on node communication.
  - Expanded transaction handling capabilities to support comprehensive transaction signing and structuring.

- **Bug Fixes**
  - Modified the initialization process of the node in tests for improved flexibility in handling parameters.

- **Refactor**
  - Updated multiple function signatures to incorporate new client context parameters for better handling of client-specific information in various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->