### PR TITLE
Clean up Monomer EVM chain config

### DIFF
--- a/evm/evm.go
+++ b/evm/evm.go
@@ -31,12 +31,9 @@ func NewEVM(ethState vm.StateDB, header *monomer.Header) (*vm.EVM, error) {
 		PetersburgBlock:     new(big.Int),
 		IstanbulBlock:       new(big.Int),
 		MuirGlacierBlock:    new(big.Int),
-		// TODO: investigate SSTORE access list EVM execution bug with BerlinBlock/LondonBlock
-		// BerlinBlock:        new(big.Int),
-		// LondonBlock:        new(big.Int),
-		ArrowGlacierBlock:  new(big.Int),
-		GrayGlacierBlock:   new(big.Int),
-		MergeNetsplitBlock: new(big.Int),
+		ArrowGlacierBlock:   new(big.Int),
+		GrayGlacierBlock:    new(big.Int),
+		MergeNetsplitBlock:  new(big.Int),
 
 		BedrockBlock: new(big.Int),
 		RegolithTime: utils.Ptr(uint64(0)),


### PR DESCRIPTION
Closes #104 
## Context
Berlin and London hardforks primarily introduce gas-related changes. Since Monomer doesn't currently account for gas, these forks may be unnecessary for the Monomer EVM.

## Changes
- Remove commented Berlin and London fork activations in [Monomer EVM](https://github.com/polymerdao/monomer/blob/89a182fcad9f7e0ae94de3b3defb93ea409f8a96/evm/evm.go#L34-L36)
- There is also no need for shared EVM config variable between [RPCMarshalBlock](https://github.com/polymerdao/monomer/blob/89a182fcad9f7e0ae94de3b3defb93ea409f8a96/eth/internal/ethapi/helpers.go#L20) and Monomer EVM, since `RPCMarshalBlock` needs both Berlin and London fork activations but Monomer EVM doesn't


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
    - Cleaned up commented-out code related to outdated block references, streamlining the codebase for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->