### PR TITLE
Upgrade buf to v1.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-gofumpt:
 
 .PHONY: install-buf
 install-buf:
-	go install github.com/bufbuild/buf/cmd/buf@v1.31.0
+	go install github.com/bufbuild/buf/cmd/buf@v1.32.0
 	go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@v1.5.0
 
 .PHONY: install-go-test-coverage


### PR DESCRIPTION
Buf configuration files were migrated from v1 to v2 in https://github.com/polymerdao/monomer/pull/125. However, our default buf installation created with the `make install-buf` command is still on a version of buf that doesn't support v2 so we can't properly generate protobuf files. To fix this, buf was upgraded from v1.31.0 to v1.32.0 in the Makefile installation command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the installation of the `buf` command to version 1.32.0, enhancing tool functionality and potentially improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->