### PR TITLE
CI: enforce protobuf pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           config: .testcoverage.yml
 
-  unit:
+  short:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  short:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - run: make test
-
   devrequirements:
     runs-on: macos-latest
     steps:
@@ -54,6 +45,15 @@ jobs:
       - uses: vladopajic/go-test-coverage@v2
         with:
           config: .testcoverage.yml
+
+  unit:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make test
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,24 @@ jobs:
           go-version-file: go.mod
       - run: make install-buf
 
+  verify-generated-code:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make install-buf
+      - run: make gen-proto
+      - name: Check for changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Generated code is not up to date. Please run 'make gen-proto' locally and commit the changes."
+            git status
+            git diff
+            exit 1
+          fi
+
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This repo contains generated code as checked-in source.

This change adds a CI check that the pipeline for generated (`source`, `buildsteps`, `outputs`) code is intact, and prevents accidentally merging, eg, changes to a protobuf definition file without corresponding changes to generated outputs.

Should prevent issues as described in #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job to verify generated code, ensuring it is up-to-date and prompting users for local actions if discrepancies arise.
	- Added a new testing job to enhance the overall CI/CD process.
  
- **Improvements**
	- Renamed existing jobs for clarity and better functionality, improving the development workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->