### PR TITLE
CI: Add an OS matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  matrix-setup:
+    runs-on: ubuntu-latest
+    outputs:
+      os-matrix: ${{ steps.set-matrix.outputs.os-matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo 'os-matrix=["ubuntu-latest", "macos-latest"]' >> $GITHUB_OUTPUT
+
   devrequirements:
-    runs-on: macos-latest
+    needs: matrix-setup
+    strategy:
+      matrix:
+        os: ${{ fromJson(needs.matrix-setup.outputs.os-matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -17,7 +30,11 @@ jobs:
       - run: make install-buf
 
   verify-generated-code:
-    runs-on: macos-latest
+    needs: matrix-setup
+    strategy:
+      matrix:
+        os: ${{ fromJson(needs.matrix-setup.outputs.os-matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -35,7 +52,11 @@ jobs:
           fi
 
   coverage:
-    runs-on: ubuntu-latest
+    needs: matrix-setup
+    strategy:
+      matrix:
+        os: ${{ fromJson(needs.matrix-setup.outputs.os-matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -47,7 +68,11 @@ jobs:
           config: .testcoverage.yml
 
   short:
-    runs-on: macos-latest
+    needs: matrix-setup
+    strategy:
+      matrix:
+        os: ${{ fromJson(needs.matrix-setup.outputs.os-matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -56,7 +81,11 @@ jobs:
       - run: make test
 
   e2e:
-    runs-on: ubuntu-latest
+    needs: matrix-setup
+    strategy:
+      matrix:
+        os: ${{ fromJson(needs.matrix-setup.outputs.os-matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,7 @@ jobs:
           fi
 
   coverage:
-    needs: matrix-setup
-    strategy:
-      matrix:
-        os: ${{ fromJson(needs.matrix-setup.outputs.os-matrix) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest # action go-test-coverage not available on macos
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,5 +99,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: e2e-logs
+          name: e2e-logs-${{ matrix.os }}
           path: e2e/artifacts/


### PR DESCRIPTION
Previously, CI checks were running in a seemingly random fashion against either `macos-latest` or `ubuntu-latest`.

There are devs on the project (current and likely into the future) on both platforms.

Two reasons *not* to include this:
- it adds some verbosity to the CI config file
- it probably makes the CI itself slower

Personally: I don't hate slow CI for merges into main. Fast feedback remains available on local machine via the makefile tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new job for setting up a matrix of operating systems in the CI/CD workflow, enhancing testing capabilities across multiple platforms.

- **Improvements**
	- Updated existing jobs to run on dynamically selected operating systems, improving efficiency and flexibility of the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->