### PR TITLE
Add `mint_eth` check on e2e desposit test

### DIFF
--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -155,20 +155,20 @@ func TestE2E(t *testing.T) {
 	)
 	require.NoError(t, err, "deposit tx")
 
-	client, err := bftclient.New(monomerCometURL.String(), monomerCometURL.String())
+	appchainClient, err := bftclient.New(monomerCometURL.String(), monomerCometURL.String())
 	require.NoError(t, err, "create Comet client")
 
 	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
 	bftTx := bfttypes.Tx(txBytes)
 
-	putTx, err := client.BroadcastTxAsync(ctx, txBytes)
+	putTx, err := appchainClient.BroadcastTxAsync(ctx, txBytes)
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, putTx.Code, "put.Code is not OK")
 	require.EqualValues(t, bftTx.Hash(), putTx.Hash, "put.Hash does not match local hash")
 	t.Log("Monomer can ingest cometbft txs")
 
 	badPutTx := []byte("malformed")
-	badPut, err := client.BroadcastTxAsync(ctx, badPutTx)
+	badPut, err := appchainClient.BroadcastTxAsync(ctx, badPutTx)
 	require.NoError(t, err) // no API error - failure encoded in response
 	require.NotEqual(t, badPut.Code, abcitypes.CodeTypeOK, "badPut.Code is OK")
 	t.Log("Monomer can reject malformed cometbft txs")
@@ -184,7 +184,7 @@ func TestE2E(t *testing.T) {
 	}
 	t.Log("Monomer can sync")
 
-	getTx, err := client.Tx(ctx, bftTx.Hash(), false)
+	getTx, err := appchainClient.Tx(ctx, bftTx.Hash(), false)
 
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, getTx.TxResult.Code, "txResult.Code is not OK")

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -251,17 +251,17 @@ func requireEthIsMinted(t *testing.T, appchainClient *bftclient.HTTP) {
 
 	require.NoError(t, err, "search transactions")
 
-	eth_minted := false
+	ethMinted := false
 
 	for _, tx := range result.Txs {
 		for _, event := range tx.TxResult.Events {
 			if event.Type == rolluptypes.EventTypeMintETH {
-				eth_minted = true
+				ethMinted = true
 			}
 		}
 	}
 
-	require.True(t, eth_minted, "mint_eth event not found")
+	require.True(t, ethMinted, "mint_eth event not found")
 	t.Log("Monomer can mint_eth from L1 user deposits")
 }
 


### PR DESCRIPTION
PR "closes the loop" of the e2e L1-L2 deposits workflow by inspecting L2 for an emitted `rolluptypes.EventTypeMintETH` event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced end-to-end testing capabilities with the addition of a function to verify ETH minting events.
  
- **Improvements**
	- Improved clarity in testing code through variable renaming for better context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->