### PR TITLE
Rename msg/query names to follow cosmos sdk standards

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -44,7 +44,7 @@ func AdaptPayloadTxsToCosmosTxs(ethTxs []hexutil.Bytes, signTx txSigner, from st
 	for _, depositTx := range ethTxs[:numDepositTxs] {
 		depositTxsBytes = append(depositTxsBytes, depositTx)
 	}
-	msgAny, err := codectypes.NewAnyWithValue(&rolluptypes.ApplyL1TxsRequest{
+	msgAny, err := codectypes.NewAnyWithValue(&rolluptypes.MsgApplyL1Txs{
 		TxBytes:     depositTxsBytes,
 		FromAddress: from,
 	})
@@ -99,7 +99,7 @@ func AdaptCosmosTxsToEthTxs(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, erro
 	if num := len(msgs); num != 1 {
 		return nil, fmt.Errorf("unexpected number of msgs in Eth Cosmos tx: want 1, got %d", num)
 	}
-	msg := new(rolluptypes.ApplyL1TxsRequest)
+	msg := new(rolluptypes.MsgApplyL1Txs)
 	if err := msg.Unmarshal(msgs[0].GetValue()); err != nil {
 		return nil, fmt.Errorf("unmarshal MsgL1Txs smsg: %v", err)
 	}

--- a/buf.yaml
+++ b/buf.yaml
@@ -10,10 +10,17 @@ deps:
 lint:
   use:
     - DEFAULT
+    - FILE_LOWER_SNAKE_CASE
+    - COMMENTS
   except:
     - FIELD_NOT_REQUIRED
     - PACKAGE_NO_IMPORT_CYCLE
-  disallow_comment_ignores: true
+    - UNARY_RPC
+    - COMMENT_FIELD
+    - SERVICE_SUFFIX
+    - PACKAGE_VERSION_SUFFIX
+    - RPC_REQUEST_STANDARD_NAME
+    - ENUM_NO_ALLOW_ALIAS
 breaking:
   use:
     - FILE

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -254,10 +254,10 @@ func (b *Builder) parseWithdrawalMessages(
 			return nil, fmt.Errorf("unmarshal cosmos tx: %v", err)
 		}
 		for _, msg := range cosmosTx.GetBody().GetMessages() {
-			withdrawalMsg := new(rolluptypes.InitiateWithdrawalRequest)
+			withdrawalMsg := new(rolluptypes.MsgInitiateWithdrawal)
 			if msg.TypeUrl == cdctypes.MsgTypeURL(withdrawalMsg) {
 				if err := withdrawalMsg.Unmarshal(msg.GetValue()); err != nil {
-					return nil, fmt.Errorf("unmarshal InitiateWithdrawalRequest: %v", err)
+					return nil, fmt.Errorf("unmarshal MsgInitiateWithdrawal: %v", err)
 				}
 
 				// Store the withdrawal message hash in the monomer EVM state db.
@@ -284,7 +284,7 @@ func (b *Builder) parseWithdrawalMessages(
 // storeWithdrawalMsgInEVM stores the withdrawal message hash in the monomer evm state db and returns the L2ToL1MessagePasser
 // message nonce used for the withdrawal. This is used for proving withdrawals.
 func (b *Builder) storeWithdrawalMsgInEVM(
-	withdrawalMsg *rolluptypes.InitiateWithdrawalRequest,
+	withdrawalMsg *rolluptypes.MsgInitiateWithdrawal,
 	ethState *state.StateDB,
 	header *monomer.Header,
 ) (*big.Int, error) {

--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -58,7 +58,7 @@ func TestABCI(t *testing.T) {
 	infoResult, err := abci.Info(&jsonrpctypes.Context{})
 	require.NoError(t, err)
 	require.Equal(t, height, infoResult.Response.LastBlockHeight) // We trust that the other fields are set properly.
-	requestBytes, err := (&testmoduletypes.GetRequest{
+	requestBytes, err := (&testmoduletypes.QueryValueRequest{
 		Key: k,
 	}).Marshal()
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestABCI(t *testing.T) {
 	// Query.
 	queryResult, err := abci.Query(&jsonrpctypes.Context{}, testapp.QueryPath, requestBytes, height, false)
 	require.NoError(t, err)
-	var val testmoduletypes.GetResponse
+	var val testmoduletypes.QueryValueResponse
 	require.NoError(t, (&val).Unmarshal(queryResult.Response.GetValue()))
 	require.Equal(t, v, val.GetValue())
 }

--- a/gen/rollup/module/v1/module.pb.go
+++ b/gen/rollup/module/v1/module.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Module is the config object for the x/rollup module.
 type Module struct {
 }
 

--- a/gen/testapp/module/v1/module.pb.go
+++ b/gen/testapp/module/v1/module.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Module is the config object for the x/testmodule module.
 type Module struct {
 }
 

--- a/proto/rollup/module/v1/module.proto
+++ b/proto/rollup/module/v1/module.proto
@@ -6,6 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 option go_package = "github.com/polymerdao/monomer/gen/rollup/module/v1;modulev1";
 
+// Module is the config object for the x/rollup module.
 message Module {
   option (cosmos.app.v1alpha1.module) = {
     go_import: "github.com/polymerdao/monomer/x/rollup"

--- a/proto/rollup/v1/tx.proto
+++ b/proto/rollup/v1/tx.proto
@@ -9,28 +9,34 @@ import "gogoproto/gogo.proto";
 
 option go_package = "github.com/polymerdao/monomer/x/rollup/types";
 
-// MsgService defines all tx endpoints for the rollup module.
-service MsgService {
-  rpc ApplyL1Txs(ApplyL1TxsRequest) returns (ApplyL1TxsResponse);
-  rpc InitiateWithdrawal(InitiateWithdrawalRequest) returns (InitiateWithdrawalResponse);
+// Msg defines all tx endpoints for the x/rollup module.
+service Msg {
+  // ApplyL1Txs defines a method for applying applying all L1 system and user deposit txs.
+  rpc ApplyL1Txs(MsgApplyL1Txs) returns (MsgApplyL1TxsResponse);
+
+  // InitiateWithdrawal defines a method for initiating a withdrawal from L2 to L1.
+  rpc InitiateWithdrawal(MsgInitiateWithdrawal) returns (MsgInitiateWithdrawalResponse);
 }
 
-// ApplyL1TxsRequest defines a message for all L1 system and user deposit txs
-message ApplyL1TxsRequest {
+// MsgApplyL1Txs defines the message for applying all L1 system and user deposit txs.
+message MsgApplyL1Txs {
   option (cosmos.msg.v1.signer) = "from_address";
 
   // Array of bytes where each bytes is a eth.Transaction.MarshalBinary tx.
   // The first tx must be the L1 system deposit tx, and the rest are user txs if present.
   repeated bytes tx_bytes = 1;
 
+  // The cosmos address of the L1 system and user deposit tx signer.
   string from_address = 2;
 }
 
-message ApplyL1TxsResponse {}
+// MsgApplyL1TxsResponse defines the Msg/ApplyL1Txs response type.
+message MsgApplyL1TxsResponse {}
 
-// InitiateWithdrawalRequest defines a message for all L2 withdrawal txs
-message InitiateWithdrawalRequest {
+// MsgInitiateWithdrawal defines the message for initiating an L2 withdrawal.
+message MsgInitiateWithdrawal {
   option (cosmos.msg.v1.signer) = "sender";
+
   // The cosmos address of the user who wants to withdraw from L2.
   string sender = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The ethereum address on L1 that the user wants to withdraw to.
@@ -48,4 +54,5 @@ message InitiateWithdrawalRequest {
   bytes data = 5;
 }
 
-message InitiateWithdrawalResponse {}
+// MsgInitiateWithdrawalResponse defines the Msg/InitiateWithdrawal response type.
+message MsgInitiateWithdrawalResponse {}

--- a/testapp/helpers.go
+++ b/testapp/helpers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const QueryPath = "/testapp.v1.QueryService/Get"
+const QueryPath = "/testapp.v1.Query/Value"
 
 func NewTest(t *testing.T, chainID string) *App {
 	appdb := dbm.NewMemDB()
@@ -49,7 +49,7 @@ func MakeGenesisAppState(t *testing.T, app *App, kvs ...string) map[string]json.
 }
 
 func ToTx(t *testing.T, k, v string) []byte {
-	msgAny, err := codectypes.NewAnyWithValue(&types.SetRequest{
+	msgAny, err := codectypes.NewAnyWithValue(&types.MsgSetValue{
 		// TODO use real addresses and enable the signature and gas checks.
 		// This is just a dummy address. The signature and gas checks are disabled in testapp.go,
 		// so this works for now.
@@ -72,7 +72,7 @@ func ToTx(t *testing.T, k, v string) []byte {
 	return txBytes
 }
 
-// ToTxs converts the key-values to SetRequest sdk.Msgs and marshals the messages to protobuf wire format.
+// ToTxs converts the key-values to MsgSetValue sdk.Msgs and marshals the messages to protobuf wire format.
 // Each message is placed in a separate tx.
 func ToTxs(t *testing.T, kvs map[string]string) [][]byte {
 	var txs [][]byte
@@ -100,7 +100,7 @@ func (a *App) StateContains(t *testing.T, height uint64, kvs map[string]string) 
 	}
 	gotState := make(map[string]string, len(kvs))
 	for k := range kvs {
-		requestBytes, err := (&types.GetRequest{
+		requestBytes, err := (&types.QueryValueRequest{
 			Key: k,
 		}).Marshal()
 		require.NoError(t, err)
@@ -110,7 +110,7 @@ func (a *App) StateContains(t *testing.T, height uint64, kvs map[string]string) 
 			Height: int64(height),
 		})
 		require.NoError(t, err)
-		var val types.GetResponse
+		var val types.QueryValueResponse
 		require.NoError(t, (&val).Unmarshal(resp.GetValue()))
 		gotState[k] = val.GetValue()
 	}
@@ -123,7 +123,7 @@ func (a *App) StateDoesNotContain(t *testing.T, height uint64, kvs map[string]st
 		return
 	}
 	for k := range kvs {
-		requestBytes, err := (&types.GetRequest{
+		requestBytes, err := (&types.QueryValueRequest{
 			Key: k,
 		}).Marshal()
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func (a *App) StateDoesNotContain(t *testing.T, height uint64, kvs map[string]st
 			Height: int64(height),
 		})
 		require.NoError(t, err)
-		var val types.GetResponse
+		var val types.QueryValueResponse
 		require.NoError(t, (&val).Unmarshal(resp.GetValue()))
 		require.Empty(t, val.GetValue())
 	}

--- a/testapp/proto/testapp/module/v1/module.proto
+++ b/testapp/proto/testapp/module/v1/module.proto
@@ -6,6 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 option go_package = "github.com/polymerdao/monomer/gen/testapp/module/v1;modulev1";
 
+// Module is the config object for the x/testmodule module.
 message Module {
   option (cosmos.app.v1alpha1.module) = {
     go_import: "github.com/polymerdao/monomer/testapp/x/testmodule"

--- a/testapp/proto/testapp/v1/query.proto
+++ b/testapp/proto/testapp/v1/query.proto
@@ -4,14 +4,18 @@ package testapp.v1;
 
 option go_package = "github.com/polymerdao/monomer/testapp/x/testmodule/types";
 
-service QueryService {
-    rpc Get(GetRequest) returns (GetResponse) {}
+// Query defines the gRPC querier service.
+service Query {
+    // Value queries a value stored at a given key.
+    rpc Value(QueryValueRequest) returns (QueryValueResponse) {}
 }
 
-message GetRequest {
+// QueryValueRequest is the request type for the Query/Value method.
+message QueryValueRequest {
     string key = 1;
 }
 
-message GetResponse {
+// QueryValueResponse is the response type for the Query/Value method.
+message QueryValueResponse {
     string value = 2;
 }

--- a/testapp/proto/testapp/v1/tx.proto
+++ b/testapp/proto/testapp/v1/tx.proto
@@ -6,11 +6,14 @@ import "cosmos/msg/v1/msg.proto";
 
 option go_package = "github.com/polymerdao/monomer/testapp/x/testmodule/types";
 
-service MsgService {
-    rpc Set(SetRequest) returns (SetResponse) {}
+// Msg defines all tx endpoints for the x/testmodule module.
+service Msg {
+    // SetValue defines a method for setting a key-value pair.
+    rpc SetValue(MsgSetValue) returns (MsgSetValueResponse) {}
 }
 
-message SetRequest {
+// MsgSetValue defines the Msg/SetValue request type for setting a key-value pair.
+message MsgSetValue {
     option (cosmos.msg.v1.signer) = "from_address";
 
     string from_address = 1;
@@ -18,4 +21,5 @@ message SetRequest {
     string value = 3;
 }
 
-message SetResponse {}
+// MsgSetValueResponse defines the Msg/SetValue response type.
+message MsgSetValueResponse {}

--- a/testapp/x/testmodule/keeper/keeper.go
+++ b/testapp/x/testmodule/keeper/keeper.go
@@ -29,7 +29,7 @@ func (m *Keeper) InitGenesis(ctx context.Context, kvs map[string]string) error {
 	return nil
 }
 
-func (m *Keeper) Get(ctx context.Context, req *types.GetRequest) (*types.GetResponse, error) {
+func (m *Keeper) Value(ctx context.Context, req *types.QueryValueRequest) (*types.QueryValueResponse, error) {
 	key := req.GetKey()
 	if key == "" {
 		return nil, errors.New("empty key")
@@ -44,15 +44,15 @@ func (m *Keeper) Get(ctx context.Context, req *types.GetRequest) (*types.GetResp
 	} else {
 		value = string(valueBytes)
 	}
-	return &types.GetResponse{
+	return &types.QueryValueResponse{
 		Value: value,
 	}, nil
 }
 
-func (m *Keeper) Set(ctx context.Context, req *types.SetRequest) (*types.SetResponse, error) {
+func (m *Keeper) SetValue(ctx context.Context, req *types.MsgSetValue) (*types.MsgSetValueResponse, error) {
 	key := req.GetKey()
 	if err := m.storeService.OpenKVStore(ctx).Set([]byte(key), []byte(req.GetValue())); err != nil {
 		return nil, fmt.Errorf("set: %v", err)
 	}
-	return &types.SetResponse{}, nil
+	return &types.MsgSetValueResponse{}, nil
 }

--- a/testapp/x/testmodule/module.go
+++ b/testapp/x/testmodule/module.go
@@ -131,6 +131,6 @@ func (*Module) RegisterInterfaces(r codectypes.InterfaceRegistry) {
 func (*Module) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {}
 
 func (m *Module) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServiceServer(cfg.MsgServer(), m.keeper)
-	types.RegisterQueryServiceServer(cfg.QueryServer(), m.keeper)
+	types.RegisterMsgServer(cfg.MsgServer(), m.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), m.keeper)
 }

--- a/testapp/x/testmodule/types/codec.go
+++ b/testapp/x/testmodule/types/codec.go
@@ -6,5 +6,5 @@ import (
 )
 
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-	msgservice.RegisterMsgServiceDesc(registry, &_MsgService_serviceDesc)
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/testapp/x/testmodule/types/msgs.go
+++ b/testapp/x/testmodule/types/msgs.go
@@ -2,8 +2,8 @@ package types
 
 import sdktypes "github.com/cosmos/cosmos-sdk/types"
 
-var _ sdktypes.Msg = (*SetRequest)(nil)
+var _ sdktypes.Msg = (*MsgSetValue)(nil)
 
-func (m *SetRequest) ValidateBasic() error {
+func (m *MsgSetValue) ValidateBasic() error {
 	return nil
 }

--- a/testapp/x/testmodule/types/query.pb.go
+++ b/testapp/x/testmodule/types/query.pb.go
@@ -27,22 +27,23 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type GetRequest struct {
+// QueryValueRequest is the request type for the Query/Value method.
+type QueryValueRequest struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 }
 
-func (m *GetRequest) Reset()         { *m = GetRequest{} }
-func (m *GetRequest) String() string { return proto.CompactTextString(m) }
-func (*GetRequest) ProtoMessage()    {}
-func (*GetRequest) Descriptor() ([]byte, []int) {
+func (m *QueryValueRequest) Reset()         { *m = QueryValueRequest{} }
+func (m *QueryValueRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryValueRequest) ProtoMessage()    {}
+func (*QueryValueRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a46aca67c2f4f0f2, []int{0}
 }
-func (m *GetRequest) XXX_Unmarshal(b []byte) error {
+func (m *QueryValueRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *GetRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueryValueRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_GetRequest.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryValueRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -52,41 +53,42 @@ func (m *GetRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *GetRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetRequest.Merge(m, src)
+func (m *QueryValueRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryValueRequest.Merge(m, src)
 }
-func (m *GetRequest) XXX_Size() int {
+func (m *QueryValueRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *GetRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetRequest.DiscardUnknown(m)
+func (m *QueryValueRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryValueRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetRequest proto.InternalMessageInfo
+var xxx_messageInfo_QueryValueRequest proto.InternalMessageInfo
 
-func (m *GetRequest) GetKey() string {
+func (m *QueryValueRequest) GetKey() string {
 	if m != nil {
 		return m.Key
 	}
 	return ""
 }
 
-type GetResponse struct {
+// QueryValueResponse is the response type for the Query/Value method.
+type QueryValueResponse struct {
 	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }
 
-func (m *GetResponse) Reset()         { *m = GetResponse{} }
-func (m *GetResponse) String() string { return proto.CompactTextString(m) }
-func (*GetResponse) ProtoMessage()    {}
-func (*GetResponse) Descriptor() ([]byte, []int) {
+func (m *QueryValueResponse) Reset()         { *m = QueryValueResponse{} }
+func (m *QueryValueResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryValueResponse) ProtoMessage()    {}
+func (*QueryValueResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a46aca67c2f4f0f2, []int{1}
 }
-func (m *GetResponse) XXX_Unmarshal(b []byte) error {
+func (m *QueryValueResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *GetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueryValueResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_GetResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryValueResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -96,19 +98,19 @@ func (m *GetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
-func (m *GetResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetResponse.Merge(m, src)
+func (m *QueryValueResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryValueResponse.Merge(m, src)
 }
-func (m *GetResponse) XXX_Size() int {
+func (m *QueryValueResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *GetResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetResponse.DiscardUnknown(m)
+func (m *QueryValueResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryValueResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetResponse proto.InternalMessageInfo
+var xxx_messageInfo_QueryValueResponse proto.InternalMessageInfo
 
-func (m *GetResponse) GetValue() string {
+func (m *QueryValueResponse) GetValue() string {
 	if m != nil {
 		return m.Value
 	}
@@ -116,29 +118,29 @@ func (m *GetResponse) GetValue() string {
 }
 
 func init() {
-	proto.RegisterType((*GetRequest)(nil), "testapp.v1.GetRequest")
-	proto.RegisterType((*GetResponse)(nil), "testapp.v1.GetResponse")
+	proto.RegisterType((*QueryValueRequest)(nil), "testapp.v1.QueryValueRequest")
+	proto.RegisterType((*QueryValueResponse)(nil), "testapp.v1.QueryValueResponse")
 }
 
 func init() { proto.RegisterFile("testapp/v1/query.proto", fileDescriptor_a46aca67c2f4f0f2) }
 
 var fileDescriptor_a46aca67c2f4f0f2 = []byte{
-	// 231 bytes of a gzipped FileDescriptorProto
+	// 225 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x2b, 0x49, 0x2d, 0x2e,
 	0x49, 0x2c, 0x28, 0xd0, 0x2f, 0x33, 0xd4, 0x2f, 0x2c, 0x4d, 0x2d, 0xaa, 0xd4, 0x2b, 0x28, 0xca,
-	0x2f, 0xc9, 0x17, 0xe2, 0x82, 0x8a, 0xeb, 0x95, 0x19, 0x2a, 0xc9, 0x71, 0x71, 0xb9, 0xa7, 0x96,
-	0x04, 0xa5, 0x16, 0x96, 0xa6, 0x16, 0x97, 0x08, 0x09, 0x70, 0x31, 0x67, 0xa7, 0x56, 0x4a, 0x30,
-	0x2a, 0x30, 0x6a, 0x70, 0x06, 0x81, 0x98, 0x4a, 0xca, 0x5c, 0xdc, 0x60, 0xf9, 0xe2, 0x82, 0xfc,
-	0xbc, 0xe2, 0x54, 0x21, 0x11, 0x2e, 0xd6, 0xb2, 0xc4, 0x9c, 0xd2, 0x54, 0x09, 0x26, 0xb0, 0x12,
-	0x08, 0xc7, 0xc8, 0x83, 0x8b, 0x27, 0x10, 0x64, 0x7e, 0x70, 0x6a, 0x51, 0x59, 0x66, 0x72, 0xaa,
-	0x90, 0x05, 0x17, 0xb3, 0x7b, 0x6a, 0x89, 0x90, 0x98, 0x1e, 0xc2, 0x22, 0x3d, 0x84, 0x2d, 0x52,
-	0xe2, 0x18, 0xe2, 0x10, 0xd3, 0x95, 0x18, 0x9c, 0x82, 0x4e, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48,
-	0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x09, 0x8f, 0xe5, 0x18, 0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1,
-	0x58, 0x8e, 0x21, 0xca, 0x22, 0x3d, 0xb3, 0x24, 0xa3, 0x34, 0x49, 0x2f, 0x39, 0x3f, 0x57, 0xbf,
-	0x20, 0x3f, 0xa7, 0x32, 0x37, 0xb5, 0x28, 0x25, 0x31, 0x5f, 0x3f, 0x37, 0x3f, 0x2f, 0x3f, 0x37,
-	0xb5, 0x48, 0x1f, 0xe6, 0xd5, 0x0a, 0x30, 0x2b, 0x37, 0x3f, 0xa5, 0x34, 0x27, 0x55, 0xbf, 0xa4,
-	0xb2, 0x20, 0xb5, 0x38, 0x89, 0x0d, 0xec, 0x6b, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0x4d,
-	0x85, 0xa9, 0xaf, 0x0f, 0x01, 0x00, 0x00,
+	0x2f, 0xc9, 0x17, 0xe2, 0x82, 0x8a, 0xeb, 0x95, 0x19, 0x2a, 0xa9, 0x72, 0x09, 0x06, 0x82, 0xa4,
+	0xc2, 0x12, 0x73, 0x4a, 0x53, 0x83, 0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b, 0x84, 0x04, 0xb8, 0x98,
+	0xb3, 0x53, 0x2b, 0x25, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83, 0x40, 0x4c, 0x25, 0x2d, 0x2e, 0x21,
+	0x64, 0x65, 0xc5, 0x05, 0xf9, 0x79, 0xc5, 0xa9, 0x42, 0x22, 0x5c, 0xac, 0x65, 0x20, 0x01, 0x09,
+	0x26, 0xb0, 0x4a, 0x08, 0xc7, 0x28, 0x90, 0x8b, 0x15, 0xac, 0x56, 0xc8, 0x83, 0x8b, 0x15, 0xac,
+	0x5e, 0x48, 0x56, 0x0f, 0x61, 0xa3, 0x1e, 0x86, 0x75, 0x52, 0x72, 0xb8, 0xa4, 0x21, 0xd6, 0x28,
+	0x31, 0x38, 0x05, 0x9d, 0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x8c,
+	0x13, 0x1e, 0xcb, 0x31, 0x5c, 0x78, 0x2c, 0xc7, 0x70, 0xe3, 0xb1, 0x1c, 0x43, 0x94, 0x45, 0x7a,
+	0x66, 0x49, 0x46, 0x69, 0x92, 0x5e, 0x72, 0x7e, 0xae, 0x7e, 0x41, 0x7e, 0x4e, 0x65, 0x6e, 0x6a,
+	0x51, 0x4a, 0x62, 0xbe, 0x7e, 0x6e, 0x7e, 0x5e, 0x7e, 0x6e, 0x6a, 0x91, 0x3e, 0x2c, 0x04, 0x2a,
+	0xc0, 0xac, 0xdc, 0xfc, 0x94, 0xd2, 0x9c, 0x54, 0xfd, 0x92, 0xca, 0x82, 0xd4, 0xe2, 0x24, 0x36,
+	0x70, 0x60, 0x18, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0xfe, 0x9b, 0x80, 0xfd, 0x26, 0x01, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -149,79 +151,81 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// QueryServiceClient is the client API for QueryService service.
+// QueryClient is the client API for Query service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
-type QueryServiceClient interface {
-	Get(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetResponse, error)
+type QueryClient interface {
+	// Value queries a value stored at a given key.
+	Value(ctx context.Context, in *QueryValueRequest, opts ...grpc.CallOption) (*QueryValueResponse, error)
 }
 
-type queryServiceClient struct {
+type queryClient struct {
 	cc grpc1.ClientConn
 }
 
-func NewQueryServiceClient(cc grpc1.ClientConn) QueryServiceClient {
-	return &queryServiceClient{cc}
+func NewQueryClient(cc grpc1.ClientConn) QueryClient {
+	return &queryClient{cc}
 }
 
-func (c *queryServiceClient) Get(ctx context.Context, in *GetRequest, opts ...grpc.CallOption) (*GetResponse, error) {
-	out := new(GetResponse)
-	err := c.cc.Invoke(ctx, "/testapp.v1.QueryService/Get", in, out, opts...)
+func (c *queryClient) Value(ctx context.Context, in *QueryValueRequest, opts ...grpc.CallOption) (*QueryValueResponse, error) {
+	out := new(QueryValueResponse)
+	err := c.cc.Invoke(ctx, "/testapp.v1.Query/Value", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// QueryServiceServer is the server API for QueryService service.
-type QueryServiceServer interface {
-	Get(context.Context, *GetRequest) (*GetResponse, error)
+// QueryServer is the server API for Query service.
+type QueryServer interface {
+	// Value queries a value stored at a given key.
+	Value(context.Context, *QueryValueRequest) (*QueryValueResponse, error)
 }
 
-// UnimplementedQueryServiceServer can be embedded to have forward compatible implementations.
-type UnimplementedQueryServiceServer struct {
+// UnimplementedQueryServer can be embedded to have forward compatible implementations.
+type UnimplementedQueryServer struct {
 }
 
-func (*UnimplementedQueryServiceServer) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Get not implemented")
+func (*UnimplementedQueryServer) Value(ctx context.Context, req *QueryValueRequest) (*QueryValueResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Value not implemented")
 }
 
-func RegisterQueryServiceServer(s grpc1.Server, srv QueryServiceServer) {
-	s.RegisterService(&_QueryService_serviceDesc, srv)
+func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
+	s.RegisterService(&_Query_serviceDesc, srv)
 }
 
-func _QueryService_Get_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetRequest)
+func _Query_Value_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryValueRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(QueryServiceServer).Get(ctx, in)
+		return srv.(QueryServer).Value(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/testapp.v1.QueryService/Get",
+		FullMethod: "/testapp.v1.Query/Value",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(QueryServiceServer).Get(ctx, req.(*GetRequest))
+		return srv.(QueryServer).Value(ctx, req.(*QueryValueRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-var _QueryService_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "testapp.v1.QueryService",
-	HandlerType: (*QueryServiceServer)(nil),
+var _Query_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "testapp.v1.Query",
+	HandlerType: (*QueryServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "Get",
-			Handler:    _QueryService_Get_Handler,
+			MethodName: "Value",
+			Handler:    _Query_Value_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "testapp/v1/query.proto",
 }
 
-func (m *GetRequest) Marshal() (dAtA []byte, err error) {
+func (m *QueryValueRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -231,12 +235,12 @@ func (m *GetRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *GetRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryValueRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *GetRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryValueRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -251,7 +255,7 @@ func (m *GetRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *GetResponse) Marshal() (dAtA []byte, err error) {
+func (m *QueryValueResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -261,12 +265,12 @@ func (m *GetResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *GetResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryValueResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *GetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryValueResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -292,7 +296,7 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *GetRequest) Size() (n int) {
+func (m *QueryValueRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -305,7 +309,7 @@ func (m *GetRequest) Size() (n int) {
 	return n
 }
 
-func (m *GetResponse) Size() (n int) {
+func (m *QueryValueResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -324,7 +328,7 @@ func sovQuery(x uint64) (n int) {
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *GetRequest) Unmarshal(dAtA []byte) error {
+func (m *QueryValueRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -347,10 +351,10 @@ func (m *GetRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: GetRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryValueRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: GetRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryValueRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -406,7 +410,7 @@ func (m *GetRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *GetResponse) Unmarshal(dAtA []byte) error {
+func (m *QueryValueResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -429,10 +433,10 @@ func (m *GetResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: GetResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryValueResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: GetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryValueResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 2:

--- a/testapp/x/testmodule/types/tx.pb.go
+++ b/testapp/x/testmodule/types/tx.pb.go
@@ -28,24 +28,25 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type SetRequest struct {
+// MsgSetValue defines the Msg/SetValue request type for setting a key-value pair.
+type MsgSetValue struct {
 	FromAddress string `protobuf:"bytes,1,opt,name=from_address,json=fromAddress,proto3" json:"from_address,omitempty"`
 	Key         string `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
 	Value       string `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
 }
 
-func (m *SetRequest) Reset()         { *m = SetRequest{} }
-func (m *SetRequest) String() string { return proto.CompactTextString(m) }
-func (*SetRequest) ProtoMessage()    {}
-func (*SetRequest) Descriptor() ([]byte, []int) {
+func (m *MsgSetValue) Reset()         { *m = MsgSetValue{} }
+func (m *MsgSetValue) String() string { return proto.CompactTextString(m) }
+func (*MsgSetValue) ProtoMessage()    {}
+func (*MsgSetValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68fb7859256a2e79, []int{0}
 }
-func (m *SetRequest) XXX_Unmarshal(b []byte) error {
+func (m *MsgSetValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *SetRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgSetValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_SetRequest.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgSetValue.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -55,54 +56,55 @@ func (m *SetRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *SetRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetRequest.Merge(m, src)
+func (m *MsgSetValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgSetValue.Merge(m, src)
 }
-func (m *SetRequest) XXX_Size() int {
+func (m *MsgSetValue) XXX_Size() int {
 	return m.Size()
 }
-func (m *SetRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_SetRequest.DiscardUnknown(m)
+func (m *MsgSetValue) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgSetValue.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SetRequest proto.InternalMessageInfo
+var xxx_messageInfo_MsgSetValue proto.InternalMessageInfo
 
-func (m *SetRequest) GetFromAddress() string {
+func (m *MsgSetValue) GetFromAddress() string {
 	if m != nil {
 		return m.FromAddress
 	}
 	return ""
 }
 
-func (m *SetRequest) GetKey() string {
+func (m *MsgSetValue) GetKey() string {
 	if m != nil {
 		return m.Key
 	}
 	return ""
 }
 
-func (m *SetRequest) GetValue() string {
+func (m *MsgSetValue) GetValue() string {
 	if m != nil {
 		return m.Value
 	}
 	return ""
 }
 
-type SetResponse struct {
+// MsgSetValueResponse defines the Msg/SetValue response type.
+type MsgSetValueResponse struct {
 }
 
-func (m *SetResponse) Reset()         { *m = SetResponse{} }
-func (m *SetResponse) String() string { return proto.CompactTextString(m) }
-func (*SetResponse) ProtoMessage()    {}
-func (*SetResponse) Descriptor() ([]byte, []int) {
+func (m *MsgSetValueResponse) Reset()         { *m = MsgSetValueResponse{} }
+func (m *MsgSetValueResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgSetValueResponse) ProtoMessage()    {}
+func (*MsgSetValueResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68fb7859256a2e79, []int{1}
 }
-func (m *SetResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgSetValueResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *SetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgSetValueResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_SetResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgSetValueResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -112,45 +114,45 @@ func (m *SetResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
-func (m *SetResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetResponse.Merge(m, src)
+func (m *MsgSetValueResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgSetValueResponse.Merge(m, src)
 }
-func (m *SetResponse) XXX_Size() int {
+func (m *MsgSetValueResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *SetResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_SetResponse.DiscardUnknown(m)
+func (m *MsgSetValueResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgSetValueResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SetResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgSetValueResponse proto.InternalMessageInfo
 
 func init() {
-	proto.RegisterType((*SetRequest)(nil), "testapp.v1.SetRequest")
-	proto.RegisterType((*SetResponse)(nil), "testapp.v1.SetResponse")
+	proto.RegisterType((*MsgSetValue)(nil), "testapp.v1.MsgSetValue")
+	proto.RegisterType((*MsgSetValueResponse)(nil), "testapp.v1.MsgSetValueResponse")
 }
 
 func init() { proto.RegisterFile("testapp/v1/tx.proto", fileDescriptor_68fb7859256a2e79) }
 
 var fileDescriptor_68fb7859256a2e79 = []byte{
-	// 281 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x90, 0xb1, 0x4e, 0xf3, 0x30,
-	0x14, 0x85, 0x93, 0xbf, 0xfa, 0x91, 0x70, 0x41, 0x02, 0x83, 0x68, 0xd4, 0xc1, 0x82, 0x4c, 0x88,
-	0x21, 0x56, 0x61, 0xa9, 0xd8, 0x60, 0x60, 0x63, 0x49, 0x36, 0x16, 0x94, 0x26, 0x97, 0x50, 0x88,
-	0x7b, 0x8d, 0xaf, 0x13, 0x35, 0x2b, 0x4f, 0xc0, 0xa3, 0xf0, 0x18, 0x8c, 0x1d, 0x19, 0x51, 0x32,
-	0xf0, 0x1a, 0x28, 0x09, 0xa8, 0x42, 0x6c, 0xc7, 0x9f, 0x8f, 0xce, 0x3d, 0x3a, 0x6c, 0xcf, 0x02,
-	0xd9, 0x58, 0x6b, 0x59, 0x4e, 0xa4, 0x5d, 0x06, 0xda, 0xa0, 0x45, 0xce, 0xbe, 0x61, 0x50, 0x4e,
-	0xc6, 0xa3, 0x04, 0x49, 0x21, 0x49, 0x45, 0x59, 0xeb, 0x51, 0x94, 0xf5, 0x26, 0xff, 0x81, 0xb1,
-	0x08, 0x6c, 0x08, 0x4f, 0x05, 0x90, 0xe5, 0x47, 0x6c, 0xeb, 0xce, 0xa0, 0xba, 0x8d, 0xd3, 0xd4,
-	0x00, 0x91, 0xe7, 0x1e, 0xba, 0xc7, 0x9b, 0xe1, 0xb0, 0x65, 0x17, 0x3d, 0xe2, 0x3b, 0x6c, 0xf0,
-	0x08, 0x95, 0xf7, 0xaf, 0xfb, 0x69, 0x25, 0xdf, 0x67, 0xff, 0xcb, 0x38, 0x2f, 0xc0, 0x1b, 0x74,
-	0xac, 0x7f, 0x9c, 0xef, 0x3e, 0x7f, 0xbe, 0x9e, 0xfc, 0x4a, 0xf3, 0xb7, 0xd9, 0xb0, 0xbb, 0x45,
-	0x1a, 0x17, 0x04, 0xa7, 0x57, 0x8c, 0x5d, 0x53, 0x16, 0x81, 0x29, 0xe7, 0x09, 0xf0, 0x29, 0x1b,
-	0x44, 0x60, 0xf9, 0x41, 0xb0, 0x6e, 0x1d, 0xac, 0x9b, 0x8d, 0x47, 0x7f, 0x78, 0x9f, 0xe2, 0x3b,
-	0x97, 0xe1, 0x5b, 0x2d, 0xdc, 0x55, 0x2d, 0xdc, 0x8f, 0x5a, 0xb8, 0x2f, 0x8d, 0x70, 0x56, 0x8d,
-	0x70, 0xde, 0x1b, 0xe1, 0xdc, 0x4c, 0xb3, 0xb9, 0xbd, 0x2f, 0x66, 0x41, 0x82, 0x4a, 0x6a, 0xcc,
-	0x2b, 0x05, 0x26, 0x8d, 0x51, 0x2a, 0x5c, 0xa0, 0x02, 0x23, 0x7f, 0x46, 0x5b, 0x76, 0x4a, 0x61,
-	0x5a, 0xe4, 0x20, 0x6d, 0xa5, 0x81, 0x66, 0x1b, 0xdd, 0x3a, 0x67, 0x5f, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0xbd, 0x43, 0xf7, 0x23, 0x59, 0x01, 0x00, 0x00,
+	// 274 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x2e, 0x49, 0x2d, 0x2e,
+	0x49, 0x2c, 0x28, 0xd0, 0x2f, 0x33, 0xd4, 0x2f, 0xa9, 0xd0, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,
+	0xe2, 0x82, 0x0a, 0xea, 0x95, 0x19, 0x4a, 0x89, 0x27, 0xe7, 0x17, 0xe7, 0xe6, 0x17, 0xeb, 0xe7,
+	0x16, 0xa7, 0x83, 0xd4, 0xe4, 0x16, 0xa7, 0x43, 0x14, 0x29, 0x65, 0x73, 0x71, 0xfb, 0x16, 0xa7,
+	0x07, 0xa7, 0x96, 0x84, 0x25, 0xe6, 0x94, 0xa6, 0x0a, 0x29, 0x72, 0xf1, 0xa4, 0x15, 0xe5, 0xe7,
+	0xc6, 0x27, 0xa6, 0xa4, 0x14, 0xa5, 0x16, 0x17, 0x4b, 0x30, 0x2a, 0x30, 0x6a, 0x70, 0x06, 0x71,
+	0x83, 0xc4, 0x1c, 0x21, 0x42, 0x42, 0x02, 0x5c, 0xcc, 0xd9, 0xa9, 0x95, 0x12, 0x4c, 0x60, 0x19,
+	0x10, 0x53, 0x48, 0x84, 0x8b, 0xb5, 0x0c, 0xa4, 0x5b, 0x82, 0x19, 0x2c, 0x06, 0xe1, 0x58, 0x09,
+	0x36, 0x3d, 0xdf, 0xa0, 0x85, 0x62, 0x9a, 0x92, 0x28, 0x97, 0x30, 0x92, 0x65, 0x41, 0xa9, 0xc5,
+	0x05, 0xf9, 0x79, 0xc5, 0xa9, 0x46, 0xbe, 0x5c, 0xcc, 0xbe, 0xc5, 0xe9, 0x42, 0x6e, 0x5c, 0x1c,
+	0x70, 0x77, 0x88, 0xeb, 0x21, 0x1c, 0xaf, 0x87, 0xa4, 0x47, 0x4a, 0x1e, 0x87, 0x04, 0xcc, 0x30,
+	0x25, 0x06, 0xa7, 0xa0, 0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92, 0x63, 0x7c, 0xf0, 0x48, 0x8e,
+	0x71, 0xc2, 0x63, 0x39, 0x86, 0x0b, 0x8f, 0xe5, 0x18, 0x6e, 0x3c, 0x96, 0x63, 0x88, 0xb2, 0x48,
+	0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x2f, 0xc8, 0xcf, 0xa9, 0xcc, 0x4d,
+	0x2d, 0x4a, 0x49, 0xcc, 0xd7, 0xcf, 0xcd, 0xcf, 0xcb, 0xcf, 0x4d, 0x2d, 0xd2, 0x87, 0x05, 0x62,
+	0x05, 0x98, 0x95, 0x9b, 0x9f, 0x52, 0x9a, 0x93, 0xaa, 0x5f, 0x52, 0x59, 0x90, 0x5a, 0x9c, 0xc4,
+	0x06, 0x0e, 0x2d, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2d, 0x4e, 0x6e, 0x87, 0x69, 0x01,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -161,79 +163,81 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// MsgServiceClient is the client API for MsgService service.
+// MsgClient is the client API for Msg service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
-type MsgServiceClient interface {
-	Set(ctx context.Context, in *SetRequest, opts ...grpc.CallOption) (*SetResponse, error)
+type MsgClient interface {
+	// SetValue defines a method for setting a key-value pair.
+	SetValue(ctx context.Context, in *MsgSetValue, opts ...grpc.CallOption) (*MsgSetValueResponse, error)
 }
 
-type msgServiceClient struct {
+type msgClient struct {
 	cc grpc1.ClientConn
 }
 
-func NewMsgServiceClient(cc grpc1.ClientConn) MsgServiceClient {
-	return &msgServiceClient{cc}
+func NewMsgClient(cc grpc1.ClientConn) MsgClient {
+	return &msgClient{cc}
 }
 
-func (c *msgServiceClient) Set(ctx context.Context, in *SetRequest, opts ...grpc.CallOption) (*SetResponse, error) {
-	out := new(SetResponse)
-	err := c.cc.Invoke(ctx, "/testapp.v1.MsgService/Set", in, out, opts...)
+func (c *msgClient) SetValue(ctx context.Context, in *MsgSetValue, opts ...grpc.CallOption) (*MsgSetValueResponse, error) {
+	out := new(MsgSetValueResponse)
+	err := c.cc.Invoke(ctx, "/testapp.v1.Msg/SetValue", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// MsgServiceServer is the server API for MsgService service.
-type MsgServiceServer interface {
-	Set(context.Context, *SetRequest) (*SetResponse, error)
+// MsgServer is the server API for Msg service.
+type MsgServer interface {
+	// SetValue defines a method for setting a key-value pair.
+	SetValue(context.Context, *MsgSetValue) (*MsgSetValueResponse, error)
 }
 
-// UnimplementedMsgServiceServer can be embedded to have forward compatible implementations.
-type UnimplementedMsgServiceServer struct {
+// UnimplementedMsgServer can be embedded to have forward compatible implementations.
+type UnimplementedMsgServer struct {
 }
 
-func (*UnimplementedMsgServiceServer) Set(ctx context.Context, req *SetRequest) (*SetResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Set not implemented")
+func (*UnimplementedMsgServer) SetValue(ctx context.Context, req *MsgSetValue) (*MsgSetValueResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetValue not implemented")
 }
 
-func RegisterMsgServiceServer(s grpc1.Server, srv MsgServiceServer) {
-	s.RegisterService(&_MsgService_serviceDesc, srv)
+func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
+	s.RegisterService(&_Msg_serviceDesc, srv)
 }
 
-func _MsgService_Set_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SetRequest)
+func _Msg_SetValue_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgSetValue)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServiceServer).Set(ctx, in)
+		return srv.(MsgServer).SetValue(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/testapp.v1.MsgService/Set",
+		FullMethod: "/testapp.v1.Msg/SetValue",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServiceServer).Set(ctx, req.(*SetRequest))
+		return srv.(MsgServer).SetValue(ctx, req.(*MsgSetValue))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-var _MsgService_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "testapp.v1.MsgService",
-	HandlerType: (*MsgServiceServer)(nil),
+var _Msg_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "testapp.v1.Msg",
+	HandlerType: (*MsgServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "Set",
-			Handler:    _MsgService_Set_Handler,
+			MethodName: "SetValue",
+			Handler:    _Msg_SetValue_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "testapp/v1/tx.proto",
 }
 
-func (m *SetRequest) Marshal() (dAtA []byte, err error) {
+func (m *MsgSetValue) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -243,12 +247,12 @@ func (m *SetRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SetRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgSetValue) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *SetRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgSetValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -277,7 +281,7 @@ func (m *SetRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *SetResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgSetValueResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -287,12 +291,12 @@ func (m *SetResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SetResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgSetValueResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *SetResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgSetValueResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -311,7 +315,7 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *SetRequest) Size() (n int) {
+func (m *MsgSetValue) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -332,7 +336,7 @@ func (m *SetRequest) Size() (n int) {
 	return n
 }
 
-func (m *SetResponse) Size() (n int) {
+func (m *MsgSetValueResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -347,7 +351,7 @@ func sovTx(x uint64) (n int) {
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *SetRequest) Unmarshal(dAtA []byte) error {
+func (m *MsgSetValue) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -370,10 +374,10 @@ func (m *SetRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SetRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgSetValue: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SetRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgSetValue: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -493,7 +497,7 @@ func (m *SetRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *SetResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgSetValueResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -516,10 +520,10 @@ func (m *SetResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SetResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgSetValueResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SetResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgSetValueResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -16,14 +16,14 @@ type msgServer struct {
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper *Keeper) types.MsgServiceServer {
+func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServiceServer = msgServer{}
+var _ types.MsgServer = msgServer{}
 
 // ApplyL1Txs implements types.MsgServer.
-func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.ApplyL1TxsRequest) (*types.ApplyL1TxsResponse, error) {
+func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*types.MsgApplyL1TxsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	ctx.Logger().Debug("Processing L1 txs", "txCount", len(msg.TxBytes))
@@ -57,13 +57,13 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.ApplyL1TxsRequest)
 		return nil, types.WrapError(types.ErrProcessL1UserDepositTxs, "err: %v", err)
 	}
 
-	return &types.ApplyL1TxsResponse{}, nil
+	return &types.MsgApplyL1TxsResponse{}, nil
 }
 
 func (k *Keeper) InitiateWithdrawal(
 	goCtx context.Context,
-	msg *types.InitiateWithdrawalRequest,
-) (*types.InitiateWithdrawalResponse, error) {
+	msg *types.MsgInitiateWithdrawal,
+) (*types.MsgInitiateWithdrawalResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	ctx.Logger().Debug("Withdrawing L2 assets", "sender", msg.Sender, "value", msg.Value)
 
@@ -101,5 +101,5 @@ func (k *Keeper) InitiateWithdrawal(
 		),
 	})
 
-	return &types.InitiateWithdrawalResponse{}, nil
+	return &types.MsgInitiateWithdrawalResponse{}, nil
 }

--- a/x/rollup/module.go
+++ b/x/rollup/module.go
@@ -150,7 +150,7 @@ func (AppModule) QuerierRoute() string { return types.QuerierRoute }
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServiceServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 }
 
 // RegisterInvariants registers the capability module's invariants.

--- a/x/rollup/types/codec.go
+++ b/x/rollup/types/codec.go
@@ -6,5 +6,5 @@ import (
 )
 
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-	msgservice.RegisterMsgServiceDesc(registry, &_MsgService_serviceDesc)
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/rollup/types/msgs.go
+++ b/x/rollup/types/msgs.go
@@ -14,26 +14,26 @@ const (
 	MaxTxGasLimit = params.MaxGasLimit
 )
 
-var _ sdktypes.Msg = (*ApplyL1TxsRequest)(nil)
+var _ sdktypes.Msg = (*MsgApplyL1Txs)(nil)
 
-func (m *ApplyL1TxsRequest) ValidateBasic() error {
+func (m *MsgApplyL1Txs) ValidateBasic() error {
 	if m.TxBytes == nil || len(m.TxBytes) < 1 {
 		return WrapError(ErrInvalidL1Txs, "must have at least one L1 Info Deposit tx")
 	}
 	return nil
 }
 
-func (*ApplyL1TxsRequest) Type() string {
+func (*MsgApplyL1Txs) Type() string {
 	return "l1txs"
 }
 
-func (*ApplyL1TxsRequest) Route() string {
+func (*MsgApplyL1Txs) Route() string {
 	return "rollup"
 }
 
-var _ sdktypes.Msg = (*InitiateWithdrawalRequest)(nil)
+var _ sdktypes.Msg = (*MsgInitiateWithdrawal)(nil)
 
-func (m *InitiateWithdrawalRequest) ValidateBasic() error {
+func (m *MsgInitiateWithdrawal) ValidateBasic() error {
 	// Check if the Ethereum address is valid
 	if !common.IsHexAddress(m.Target) {
 		return fmt.Errorf("invalid Ethereum address: %s", m.Target)
@@ -47,10 +47,10 @@ func (m *InitiateWithdrawalRequest) ValidateBasic() error {
 	return nil
 }
 
-func (*InitiateWithdrawalRequest) Type() string {
+func (*MsgInitiateWithdrawal) Type() string {
 	return "l2withdrawal"
 }
 
-func (*InitiateWithdrawalRequest) Route() string {
+func (*MsgInitiateWithdrawal) Route() string {
 	return "rollup"
 }

--- a/x/rollup/types/msgs_test.go
+++ b/x/rollup/types/msgs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitiateWithdrawalRequestValidateBasic(t *testing.T) {
+func TestMsgInitiateWithdrawalValidateBasic(t *testing.T) {
 	validAddress := "0x311d373126EFAE95E261DefF004FF245021739d1"
 
 	invalidAddress := "invalid address"
@@ -23,19 +23,19 @@ func TestInitiateWithdrawalRequestValidateBasic(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		request *types.InitiateWithdrawalRequest
+		request *types.MsgInitiateWithdrawal
 		errMsg  string
 	}{
 		{
 			name: "Valid request",
-			request: &types.InitiateWithdrawalRequest{
+			request: &types.MsgInitiateWithdrawal{
 				Target:   validAddress,
 				GasLimit: validGasLimit,
 			},
 		},
 		{
 			name: "Invalid Ethereum address",
-			request: &types.InitiateWithdrawalRequest{
+			request: &types.MsgInitiateWithdrawal{
 				Target:   invalidAddress,
 				GasLimit: validGasLimit,
 			},
@@ -43,7 +43,7 @@ func TestInitiateWithdrawalRequestValidateBasic(t *testing.T) {
 		},
 		{
 			name: "Gas limit below the allowed range",
-			request: &types.InitiateWithdrawalRequest{
+			request: &types.MsgInitiateWithdrawal{
 				Target:   validAddress,
 				GasLimit: belowRangeGasLimit,
 			},
@@ -51,7 +51,7 @@ func TestInitiateWithdrawalRequestValidateBasic(t *testing.T) {
 		},
 		{
 			name: "Gas limit above the allowed range",
-			request: &types.InitiateWithdrawalRequest{
+			request: &types.MsgInitiateWithdrawal{
 				Target:   validAddress,
 				GasLimit: aboveRangeGasLimit,
 			},

--- a/x/rollup/types/tx.pb.go
+++ b/x/rollup/types/tx.pb.go
@@ -32,26 +32,27 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// ApplyL1TxsRequest defines a message for all L1 system and user deposit txs
-type ApplyL1TxsRequest struct {
+// MsgApplyL1Txs defines the message for applying all L1 system and user deposit txs.
+type MsgApplyL1Txs struct {
 	// Array of bytes where each bytes is a eth.Transaction.MarshalBinary tx.
 	// The first tx must be the L1 system deposit tx, and the rest are user txs if present.
-	TxBytes     [][]byte `protobuf:"bytes,1,rep,name=tx_bytes,json=txBytes,proto3" json:"tx_bytes,omitempty"`
-	FromAddress string   `protobuf:"bytes,2,opt,name=from_address,json=fromAddress,proto3" json:"from_address,omitempty"`
+	TxBytes [][]byte `protobuf:"bytes,1,rep,name=tx_bytes,json=txBytes,proto3" json:"tx_bytes,omitempty"`
+	// The cosmos address of the L1 system and user deposit tx signer.
+	FromAddress string `protobuf:"bytes,2,opt,name=from_address,json=fromAddress,proto3" json:"from_address,omitempty"`
 }
 
-func (m *ApplyL1TxsRequest) Reset()         { *m = ApplyL1TxsRequest{} }
-func (m *ApplyL1TxsRequest) String() string { return proto.CompactTextString(m) }
-func (*ApplyL1TxsRequest) ProtoMessage()    {}
-func (*ApplyL1TxsRequest) Descriptor() ([]byte, []int) {
+func (m *MsgApplyL1Txs) Reset()         { *m = MsgApplyL1Txs{} }
+func (m *MsgApplyL1Txs) String() string { return proto.CompactTextString(m) }
+func (*MsgApplyL1Txs) ProtoMessage()    {}
+func (*MsgApplyL1Txs) Descriptor() ([]byte, []int) {
 	return fileDescriptor_106533843870de0f, []int{0}
 }
-func (m *ApplyL1TxsRequest) XXX_Unmarshal(b []byte) error {
+func (m *MsgApplyL1Txs) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *ApplyL1TxsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgApplyL1Txs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_ApplyL1TxsRequest.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgApplyL1Txs.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -61,47 +62,48 @@ func (m *ApplyL1TxsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
-func (m *ApplyL1TxsRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ApplyL1TxsRequest.Merge(m, src)
+func (m *MsgApplyL1Txs) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgApplyL1Txs.Merge(m, src)
 }
-func (m *ApplyL1TxsRequest) XXX_Size() int {
+func (m *MsgApplyL1Txs) XXX_Size() int {
 	return m.Size()
 }
-func (m *ApplyL1TxsRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ApplyL1TxsRequest.DiscardUnknown(m)
+func (m *MsgApplyL1Txs) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgApplyL1Txs.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ApplyL1TxsRequest proto.InternalMessageInfo
+var xxx_messageInfo_MsgApplyL1Txs proto.InternalMessageInfo
 
-func (m *ApplyL1TxsRequest) GetTxBytes() [][]byte {
+func (m *MsgApplyL1Txs) GetTxBytes() [][]byte {
 	if m != nil {
 		return m.TxBytes
 	}
 	return nil
 }
 
-func (m *ApplyL1TxsRequest) GetFromAddress() string {
+func (m *MsgApplyL1Txs) GetFromAddress() string {
 	if m != nil {
 		return m.FromAddress
 	}
 	return ""
 }
 
-type ApplyL1TxsResponse struct {
+// MsgApplyL1TxsResponse defines the Msg/ApplyL1Txs response type.
+type MsgApplyL1TxsResponse struct {
 }
 
-func (m *ApplyL1TxsResponse) Reset()         { *m = ApplyL1TxsResponse{} }
-func (m *ApplyL1TxsResponse) String() string { return proto.CompactTextString(m) }
-func (*ApplyL1TxsResponse) ProtoMessage()    {}
-func (*ApplyL1TxsResponse) Descriptor() ([]byte, []int) {
+func (m *MsgApplyL1TxsResponse) Reset()         { *m = MsgApplyL1TxsResponse{} }
+func (m *MsgApplyL1TxsResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgApplyL1TxsResponse) ProtoMessage()    {}
+func (*MsgApplyL1TxsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_106533843870de0f, []int{1}
 }
-func (m *ApplyL1TxsResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgApplyL1TxsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *ApplyL1TxsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgApplyL1TxsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_ApplyL1TxsResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgApplyL1TxsResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -111,20 +113,20 @@ func (m *ApplyL1TxsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-func (m *ApplyL1TxsResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ApplyL1TxsResponse.Merge(m, src)
+func (m *MsgApplyL1TxsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgApplyL1TxsResponse.Merge(m, src)
 }
-func (m *ApplyL1TxsResponse) XXX_Size() int {
+func (m *MsgApplyL1TxsResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *ApplyL1TxsResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ApplyL1TxsResponse.DiscardUnknown(m)
+func (m *MsgApplyL1TxsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgApplyL1TxsResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ApplyL1TxsResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgApplyL1TxsResponse proto.InternalMessageInfo
 
-// InitiateWithdrawalRequest defines a message for all L2 withdrawal txs
-type InitiateWithdrawalRequest struct {
+// MsgInitiateWithdrawal defines the message for initiating an L2 withdrawal.
+type MsgInitiateWithdrawal struct {
 	// The cosmos address of the user who wants to withdraw from L2.
 	Sender string `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
 	// The ethereum address on L1 that the user wants to withdraw to.
@@ -137,18 +139,18 @@ type InitiateWithdrawalRequest struct {
 	Data []byte `protobuf:"bytes,5,opt,name=data,proto3" json:"data,omitempty"`
 }
 
-func (m *InitiateWithdrawalRequest) Reset()         { *m = InitiateWithdrawalRequest{} }
-func (m *InitiateWithdrawalRequest) String() string { return proto.CompactTextString(m) }
-func (*InitiateWithdrawalRequest) ProtoMessage()    {}
-func (*InitiateWithdrawalRequest) Descriptor() ([]byte, []int) {
+func (m *MsgInitiateWithdrawal) Reset()         { *m = MsgInitiateWithdrawal{} }
+func (m *MsgInitiateWithdrawal) String() string { return proto.CompactTextString(m) }
+func (*MsgInitiateWithdrawal) ProtoMessage()    {}
+func (*MsgInitiateWithdrawal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_106533843870de0f, []int{2}
 }
-func (m *InitiateWithdrawalRequest) XXX_Unmarshal(b []byte) error {
+func (m *MsgInitiateWithdrawal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *InitiateWithdrawalRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgInitiateWithdrawal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_InitiateWithdrawalRequest.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgInitiateWithdrawal.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -158,61 +160,62 @@ func (m *InitiateWithdrawalRequest) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
-func (m *InitiateWithdrawalRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InitiateWithdrawalRequest.Merge(m, src)
+func (m *MsgInitiateWithdrawal) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgInitiateWithdrawal.Merge(m, src)
 }
-func (m *InitiateWithdrawalRequest) XXX_Size() int {
+func (m *MsgInitiateWithdrawal) XXX_Size() int {
 	return m.Size()
 }
-func (m *InitiateWithdrawalRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_InitiateWithdrawalRequest.DiscardUnknown(m)
+func (m *MsgInitiateWithdrawal) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgInitiateWithdrawal.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_InitiateWithdrawalRequest proto.InternalMessageInfo
+var xxx_messageInfo_MsgInitiateWithdrawal proto.InternalMessageInfo
 
-func (m *InitiateWithdrawalRequest) GetSender() string {
+func (m *MsgInitiateWithdrawal) GetSender() string {
 	if m != nil {
 		return m.Sender
 	}
 	return ""
 }
 
-func (m *InitiateWithdrawalRequest) GetTarget() string {
+func (m *MsgInitiateWithdrawal) GetTarget() string {
 	if m != nil {
 		return m.Target
 	}
 	return ""
 }
 
-func (m *InitiateWithdrawalRequest) GetGasLimit() []byte {
+func (m *MsgInitiateWithdrawal) GetGasLimit() []byte {
 	if m != nil {
 		return m.GasLimit
 	}
 	return nil
 }
 
-func (m *InitiateWithdrawalRequest) GetData() []byte {
+func (m *MsgInitiateWithdrawal) GetData() []byte {
 	if m != nil {
 		return m.Data
 	}
 	return nil
 }
 
-type InitiateWithdrawalResponse struct {
+// MsgInitiateWithdrawalResponse defines the Msg/InitiateWithdrawal response type.
+type MsgInitiateWithdrawalResponse struct {
 }
 
-func (m *InitiateWithdrawalResponse) Reset()         { *m = InitiateWithdrawalResponse{} }
-func (m *InitiateWithdrawalResponse) String() string { return proto.CompactTextString(m) }
-func (*InitiateWithdrawalResponse) ProtoMessage()    {}
-func (*InitiateWithdrawalResponse) Descriptor() ([]byte, []int) {
+func (m *MsgInitiateWithdrawalResponse) Reset()         { *m = MsgInitiateWithdrawalResponse{} }
+func (m *MsgInitiateWithdrawalResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgInitiateWithdrawalResponse) ProtoMessage()    {}
+func (*MsgInitiateWithdrawalResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_106533843870de0f, []int{3}
 }
-func (m *InitiateWithdrawalResponse) XXX_Unmarshal(b []byte) error {
+func (m *MsgInitiateWithdrawalResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *InitiateWithdrawalResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgInitiateWithdrawalResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_InitiateWithdrawalResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_MsgInitiateWithdrawalResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -222,60 +225,59 @@ func (m *InitiateWithdrawalResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
-func (m *InitiateWithdrawalResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InitiateWithdrawalResponse.Merge(m, src)
+func (m *MsgInitiateWithdrawalResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgInitiateWithdrawalResponse.Merge(m, src)
 }
-func (m *InitiateWithdrawalResponse) XXX_Size() int {
+func (m *MsgInitiateWithdrawalResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *InitiateWithdrawalResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_InitiateWithdrawalResponse.DiscardUnknown(m)
+func (m *MsgInitiateWithdrawalResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgInitiateWithdrawalResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_InitiateWithdrawalResponse proto.InternalMessageInfo
+var xxx_messageInfo_MsgInitiateWithdrawalResponse proto.InternalMessageInfo
 
 func init() {
-	proto.RegisterType((*ApplyL1TxsRequest)(nil), "rollup.v1.ApplyL1TxsRequest")
-	proto.RegisterType((*ApplyL1TxsResponse)(nil), "rollup.v1.ApplyL1TxsResponse")
-	proto.RegisterType((*InitiateWithdrawalRequest)(nil), "rollup.v1.InitiateWithdrawalRequest")
-	proto.RegisterType((*InitiateWithdrawalResponse)(nil), "rollup.v1.InitiateWithdrawalResponse")
+	proto.RegisterType((*MsgApplyL1Txs)(nil), "rollup.v1.MsgApplyL1Txs")
+	proto.RegisterType((*MsgApplyL1TxsResponse)(nil), "rollup.v1.MsgApplyL1TxsResponse")
+	proto.RegisterType((*MsgInitiateWithdrawal)(nil), "rollup.v1.MsgInitiateWithdrawal")
+	proto.RegisterType((*MsgInitiateWithdrawalResponse)(nil), "rollup.v1.MsgInitiateWithdrawalResponse")
 }
 
 func init() { proto.RegisterFile("rollup/v1/tx.proto", fileDescriptor_106533843870de0f) }
 
 var fileDescriptor_106533843870de0f = []byte{
-	// 490 bytes of a gzipped FileDescriptorProto
+	// 479 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x52, 0x31, 0x6f, 0x13, 0x31,
-	0x14, 0x8e, 0x69, 0x1b, 0x1a, 0x37, 0x4b, 0xac, 0x00, 0x97, 0xa3, 0x5c, 0x43, 0x04, 0x52, 0x54,
-	0xd1, 0x73, 0x03, 0x5b, 0xb7, 0x66, 0xa8, 0x14, 0xa9, 0x2c, 0x57, 0x24, 0x24, 0x96, 0xc8, 0xc9,
-	0x19, 0xc7, 0xe2, 0x7c, 0x3e, 0x6c, 0x27, 0x5c, 0x56, 0x7e, 0x01, 0x3f, 0x83, 0xb1, 0x43, 0x27,
-	0x7e, 0x41, 0xc7, 0xaa, 0x13, 0x62, 0xa8, 0x50, 0x32, 0x74, 0xe0, 0x4f, 0xa0, 0x3b, 0x1b, 0x28,
-	0x2a, 0x11, 0x8b, 0xe5, 0xef, 0xfb, 0xde, 0x7b, 0xdf, 0xf3, 0xf3, 0x83, 0x48, 0xc9, 0x24, 0x99,
-	0x66, 0x78, 0xd6, 0xc3, 0x26, 0x0f, 0x33, 0x25, 0x8d, 0x44, 0x35, 0xcb, 0x85, 0xb3, 0x9e, 0xdf,
-	0x20, 0x82, 0xa7, 0x12, 0x97, 0xa7, 0x55, 0xfd, 0x07, 0x63, 0xa9, 0x85, 0xd4, 0x58, 0x68, 0x56,
-	0x64, 0x09, 0xcd, 0x9c, 0xd0, 0xb2, 0xc2, 0xb0, 0x44, 0xd8, 0x02, 0x27, 0x35, 0x99, 0x64, 0xd2,
-	0xf2, 0xc5, 0xcd, 0xb2, 0x9d, 0x18, 0x36, 0x0e, 0xb3, 0x2c, 0x99, 0x1f, 0xf7, 0x5e, 0xe5, 0x3a,
-	0xa2, 0xef, 0xa7, 0x54, 0x1b, 0xd4, 0x82, 0x9b, 0x26, 0x1f, 0x8e, 0xe6, 0x86, 0x6a, 0x0f, 0xb4,
-	0xd7, 0xba, 0xf5, 0xe8, 0xae, 0xc9, 0xfb, 0x05, 0x44, 0x8f, 0x61, 0xfd, 0xad, 0x92, 0x62, 0x48,
-	0xe2, 0x58, 0x51, 0xad, 0xbd, 0x3b, 0x6d, 0xd0, 0xad, 0x45, 0x5b, 0x05, 0x77, 0x68, 0xa9, 0x83,
-	0xc6, 0xc7, 0xeb, 0xd3, 0xdd, 0xbf, 0xa2, 0x3a, 0x4d, 0x88, 0x6e, 0xba, 0xe8, 0x4c, 0xa6, 0x9a,
-	0x76, 0x7e, 0x00, 0xd8, 0x1a, 0xa4, 0xdc, 0x70, 0x62, 0xe8, 0x6b, 0x6e, 0x26, 0xb1, 0x22, 0x1f,
-	0x48, 0xf2, 0xab, 0x89, 0x7d, 0x58, 0xd5, 0x34, 0x8d, 0xa9, 0xf2, 0x40, 0xe1, 0xd1, 0xf7, 0x2e,
-	0xcf, 0xf6, 0x9a, 0xee, 0x45, 0xce, 0xea, 0xc4, 0x28, 0x9e, 0xb2, 0xc8, 0xc5, 0xa1, 0xfb, 0xb0,
-	0x6a, 0x88, 0x62, 0xd4, 0xb8, 0xae, 0x1c, 0x42, 0x47, 0x70, 0x63, 0x46, 0x92, 0x29, 0xf5, 0xd6,
-	0xca, 0x42, 0xfb, 0xe7, 0x57, 0x3b, 0x95, 0x6f, 0x57, 0x3b, 0xf7, 0x6c, 0x31, 0x1d, 0xbf, 0x0b,
-	0xb9, 0xc4, 0x82, 0x98, 0x49, 0x38, 0x48, 0xcd, 0xe5, 0xd9, 0x1e, 0x74, 0x2e, 0x83, 0xd4, 0x7c,
-	0xbe, 0x3e, 0xdd, 0x05, 0x91, 0x4d, 0x47, 0x0f, 0x61, 0x8d, 0x11, 0x3d, 0x4c, 0xb8, 0xe0, 0xc6,
-	0x5b, 0x6f, 0x83, 0x6e, 0x3d, 0xda, 0x64, 0x44, 0x1f, 0x17, 0x18, 0x21, 0xb8, 0x1e, 0x13, 0x43,
-	0xbc, 0x8d, 0x92, 0x2f, 0xef, 0x07, 0x5b, 0xc5, 0x24, 0x5c, 0x77, 0x9d, 0x6d, 0xe8, 0xff, 0xeb,
-	0xb1, 0x76, 0x16, 0xcf, 0xbf, 0x00, 0x08, 0x5f, 0x6a, 0x76, 0x42, 0xd5, 0x8c, 0x8f, 0x29, 0x1a,
-	0x40, 0xf8, 0x67, 0x60, 0x68, 0x3b, 0xfc, 0xbd, 0x0d, 0xe1, 0xad, 0xdf, 0xf2, 0x1f, 0xad, 0x50,
-	0x6d, 0x65, 0x44, 0x20, 0xba, 0xed, 0x8b, 0x9e, 0xdc, 0x48, 0x5a, 0xf9, 0x07, 0xfe, 0xd3, 0xff,
-	0x44, 0x59, 0x8b, 0xfe, 0xd1, 0xf9, 0x22, 0x00, 0x17, 0x8b, 0x00, 0x7c, 0x5f, 0x04, 0xe0, 0xd3,
-	0x32, 0xa8, 0x5c, 0x2c, 0x83, 0xca, 0xd7, 0x65, 0x50, 0x79, 0xf3, 0x8c, 0x71, 0x33, 0x99, 0x8e,
-	0xc2, 0xb1, 0x14, 0x38, 0x93, 0xc9, 0x5c, 0x50, 0x15, 0x13, 0x89, 0x85, 0x4c, 0xa5, 0xa0, 0x0a,
-	0xe7, 0xd8, 0xad, 0xbe, 0x99, 0x67, 0x54, 0x8f, 0xaa, 0xe5, 0x4e, 0xbe, 0xf8, 0x19, 0x00, 0x00,
-	0xff, 0xff, 0xee, 0x34, 0x5a, 0x78, 0x11, 0x03, 0x00, 0x00,
+	0x14, 0x8e, 0x49, 0x1b, 0x1a, 0x37, 0x0c, 0xb5, 0x5a, 0x7a, 0x0d, 0xe2, 0x12, 0x32, 0x45, 0x15,
+	0x3d, 0x37, 0xb0, 0x75, 0x6b, 0x86, 0x8a, 0x48, 0xed, 0x72, 0x20, 0x21, 0xb1, 0xa4, 0x4e, 0xcf,
+	0x38, 0x27, 0xce, 0xe7, 0x93, 0xfd, 0x12, 0x92, 0x95, 0x5f, 0xc0, 0xcf, 0x60, 0x2c, 0x52, 0x7f,
+	0x44, 0xc7, 0xaa, 0x13, 0x62, 0xa8, 0x50, 0x32, 0xe4, 0x6f, 0xa0, 0x3b, 0x3b, 0x88, 0x40, 0x11,
+	0xcb, 0xc9, 0xdf, 0xf7, 0xbd, 0xf7, 0x3e, 0xfb, 0xbb, 0x87, 0x89, 0x56, 0x49, 0x32, 0xca, 0xe8,
+	0xb8, 0x43, 0x61, 0x12, 0x64, 0x5a, 0x81, 0x22, 0x55, 0xcb, 0x05, 0xe3, 0x4e, 0x7d, 0x8b, 0xc9,
+	0x38, 0x55, 0xb4, 0xf8, 0x5a, 0xb5, 0xbe, 0x7b, 0xa1, 0x8c, 0x54, 0x86, 0x4a, 0x23, 0xf2, 0x2e,
+	0x69, 0x84, 0x13, 0xf6, 0xac, 0xd0, 0x2f, 0x10, 0xb5, 0xc0, 0x49, 0xdb, 0x42, 0x09, 0x65, 0xf9,
+	0xfc, 0x64, 0xd9, 0xd6, 0x39, 0x7e, 0x74, 0x66, 0xc4, 0x71, 0x96, 0x25, 0xd3, 0xd3, 0xce, 0x9b,
+	0x89, 0x21, 0x7b, 0x78, 0x03, 0x26, 0xfd, 0xc1, 0x14, 0xb8, 0xf1, 0x50, 0xb3, 0xdc, 0xae, 0x85,
+	0x0f, 0x61, 0xd2, 0xcd, 0x21, 0x79, 0x86, 0x6b, 0xef, 0xb5, 0x92, 0x7d, 0x16, 0x45, 0x9a, 0x1b,
+	0xe3, 0x3d, 0x68, 0xa2, 0x76, 0x35, 0xdc, 0xcc, 0xb9, 0x63, 0x4b, 0x1d, 0x6d, 0x7d, 0x5a, 0x5c,
+	0xee, 0xaf, 0x54, 0xb5, 0x76, 0xf1, 0xce, 0x8a, 0x43, 0xc8, 0x4d, 0xa6, 0x52, 0xc3, 0x5b, 0x0b,
+	0x54, 0x28, 0xbd, 0x34, 0x86, 0x98, 0x01, 0x7f, 0x1b, 0xc3, 0x30, 0xd2, 0xec, 0x23, 0x4b, 0xc8,
+	0x21, 0xae, 0x18, 0x9e, 0x46, 0x5c, 0x7b, 0x28, 0xb7, 0xe8, 0x7a, 0xb7, 0x57, 0x07, 0xdb, 0xee,
+	0x31, 0xce, 0xe9, 0x35, 0xe8, 0x38, 0x15, 0xa1, 0xab, 0x23, 0x8f, 0x71, 0x05, 0x98, 0x16, 0x1c,
+	0xdc, 0xa5, 0x1c, 0x22, 0x27, 0x78, 0x7d, 0xcc, 0x92, 0x11, 0xf7, 0xca, 0xc5, 0xa0, 0xc3, 0xeb,
+	0xbb, 0x46, 0xe9, 0xfb, 0x5d, 0x63, 0xc7, 0x0e, 0x33, 0xd1, 0x87, 0x20, 0x56, 0x54, 0x32, 0x18,
+	0x06, 0xbd, 0x14, 0x6e, 0xaf, 0x0e, 0xb0, 0x73, 0xe9, 0xa5, 0xf0, 0x65, 0x71, 0xb9, 0x8f, 0x42,
+	0xdb, 0x4e, 0x9e, 0xe0, 0xaa, 0x60, 0xa6, 0x9f, 0xc4, 0x32, 0x06, 0x6f, 0xad, 0x89, 0xda, 0xb5,
+	0x70, 0x43, 0x30, 0x73, 0x9a, 0x63, 0x42, 0xf0, 0x5a, 0xc4, 0x80, 0x79, 0xeb, 0x05, 0x5f, 0x9c,
+	0x8f, 0x36, 0xf3, 0x20, 0xdc, 0xed, 0x5a, 0x0d, 0xfc, 0xf4, 0xde, 0x87, 0x2e, 0xa3, 0x78, 0xf1,
+	0x15, 0xe1, 0xf2, 0x99, 0x11, 0xe4, 0x15, 0xc6, 0xbf, 0xfd, 0x0a, 0x2f, 0xf8, 0xb5, 0x04, 0xc1,
+	0x4a, 0x84, 0xf5, 0xe6, 0xbf, 0x94, 0xe5, 0x44, 0x72, 0x8e, 0xc9, 0x3d, 0xc1, 0xfe, 0xd1, 0xf7,
+	0x77, 0x45, 0xbd, 0xfd, 0xbf, 0x8a, 0xa5, 0x43, 0xf7, 0xe4, 0x7a, 0xe6, 0xa3, 0x9b, 0x99, 0x8f,
+	0x7e, 0xcc, 0x7c, 0xf4, 0x79, 0xee, 0x97, 0x6e, 0xe6, 0x7e, 0xe9, 0xdb, 0xdc, 0x2f, 0xbd, 0x7b,
+	0x2e, 0x62, 0x18, 0x8e, 0x06, 0xc1, 0x85, 0x92, 0x34, 0x53, 0xc9, 0x54, 0x72, 0x1d, 0x31, 0x45,
+	0xa5, 0x4a, 0x95, 0xe4, 0x9a, 0x4e, 0xa8, 0xdb, 0x77, 0x98, 0x66, 0xdc, 0x0c, 0x2a, 0xc5, 0x22,
+	0xbe, 0xfc, 0x19, 0x00, 0x00, 0xff, 0xff, 0xa3, 0x27, 0xf0, 0x02, 0x06, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -286,115 +288,119 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// MsgServiceClient is the client API for MsgService service.
+// MsgClient is the client API for Msg service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
-type MsgServiceClient interface {
-	ApplyL1Txs(ctx context.Context, in *ApplyL1TxsRequest, opts ...grpc.CallOption) (*ApplyL1TxsResponse, error)
-	InitiateWithdrawal(ctx context.Context, in *InitiateWithdrawalRequest, opts ...grpc.CallOption) (*InitiateWithdrawalResponse, error)
+type MsgClient interface {
+	// ApplyL1Txs defines a method for applying applying all L1 system and user deposit txs.
+	ApplyL1Txs(ctx context.Context, in *MsgApplyL1Txs, opts ...grpc.CallOption) (*MsgApplyL1TxsResponse, error)
+	// InitiateWithdrawal defines a method for initiating a withdrawal from L2 to L1.
+	InitiateWithdrawal(ctx context.Context, in *MsgInitiateWithdrawal, opts ...grpc.CallOption) (*MsgInitiateWithdrawalResponse, error)
 }
 
-type msgServiceClient struct {
+type msgClient struct {
 	cc grpc1.ClientConn
 }
 
-func NewMsgServiceClient(cc grpc1.ClientConn) MsgServiceClient {
-	return &msgServiceClient{cc}
+func NewMsgClient(cc grpc1.ClientConn) MsgClient {
+	return &msgClient{cc}
 }
 
-func (c *msgServiceClient) ApplyL1Txs(ctx context.Context, in *ApplyL1TxsRequest, opts ...grpc.CallOption) (*ApplyL1TxsResponse, error) {
-	out := new(ApplyL1TxsResponse)
-	err := c.cc.Invoke(ctx, "/rollup.v1.MsgService/ApplyL1Txs", in, out, opts...)
+func (c *msgClient) ApplyL1Txs(ctx context.Context, in *MsgApplyL1Txs, opts ...grpc.CallOption) (*MsgApplyL1TxsResponse, error) {
+	out := new(MsgApplyL1TxsResponse)
+	err := c.cc.Invoke(ctx, "/rollup.v1.Msg/ApplyL1Txs", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *msgServiceClient) InitiateWithdrawal(ctx context.Context, in *InitiateWithdrawalRequest, opts ...grpc.CallOption) (*InitiateWithdrawalResponse, error) {
-	out := new(InitiateWithdrawalResponse)
-	err := c.cc.Invoke(ctx, "/rollup.v1.MsgService/InitiateWithdrawal", in, out, opts...)
+func (c *msgClient) InitiateWithdrawal(ctx context.Context, in *MsgInitiateWithdrawal, opts ...grpc.CallOption) (*MsgInitiateWithdrawalResponse, error) {
+	out := new(MsgInitiateWithdrawalResponse)
+	err := c.cc.Invoke(ctx, "/rollup.v1.Msg/InitiateWithdrawal", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// MsgServiceServer is the server API for MsgService service.
-type MsgServiceServer interface {
-	ApplyL1Txs(context.Context, *ApplyL1TxsRequest) (*ApplyL1TxsResponse, error)
-	InitiateWithdrawal(context.Context, *InitiateWithdrawalRequest) (*InitiateWithdrawalResponse, error)
+// MsgServer is the server API for Msg service.
+type MsgServer interface {
+	// ApplyL1Txs defines a method for applying applying all L1 system and user deposit txs.
+	ApplyL1Txs(context.Context, *MsgApplyL1Txs) (*MsgApplyL1TxsResponse, error)
+	// InitiateWithdrawal defines a method for initiating a withdrawal from L2 to L1.
+	InitiateWithdrawal(context.Context, *MsgInitiateWithdrawal) (*MsgInitiateWithdrawalResponse, error)
 }
 
-// UnimplementedMsgServiceServer can be embedded to have forward compatible implementations.
-type UnimplementedMsgServiceServer struct {
+// UnimplementedMsgServer can be embedded to have forward compatible implementations.
+type UnimplementedMsgServer struct {
 }
 
-func (*UnimplementedMsgServiceServer) ApplyL1Txs(ctx context.Context, req *ApplyL1TxsRequest) (*ApplyL1TxsResponse, error) {
+func (*UnimplementedMsgServer) ApplyL1Txs(ctx context.Context, req *MsgApplyL1Txs) (*MsgApplyL1TxsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ApplyL1Txs not implemented")
 }
-func (*UnimplementedMsgServiceServer) InitiateWithdrawal(ctx context.Context, req *InitiateWithdrawalRequest) (*InitiateWithdrawalResponse, error) {
+func (*UnimplementedMsgServer) InitiateWithdrawal(ctx context.Context, req *MsgInitiateWithdrawal) (*MsgInitiateWithdrawalResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method InitiateWithdrawal not implemented")
 }
 
-func RegisterMsgServiceServer(s grpc1.Server, srv MsgServiceServer) {
-	s.RegisterService(&_MsgService_serviceDesc, srv)
+func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
+	s.RegisterService(&_Msg_serviceDesc, srv)
 }
 
-func _MsgService_ApplyL1Txs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ApplyL1TxsRequest)
+func _Msg_ApplyL1Txs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgApplyL1Txs)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServiceServer).ApplyL1Txs(ctx, in)
+		return srv.(MsgServer).ApplyL1Txs(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/rollup.v1.MsgService/ApplyL1Txs",
+		FullMethod: "/rollup.v1.Msg/ApplyL1Txs",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServiceServer).ApplyL1Txs(ctx, req.(*ApplyL1TxsRequest))
+		return srv.(MsgServer).ApplyL1Txs(ctx, req.(*MsgApplyL1Txs))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MsgService_InitiateWithdrawal_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(InitiateWithdrawalRequest)
+func _Msg_InitiateWithdrawal_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgInitiateWithdrawal)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MsgServiceServer).InitiateWithdrawal(ctx, in)
+		return srv.(MsgServer).InitiateWithdrawal(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/rollup.v1.MsgService/InitiateWithdrawal",
+		FullMethod: "/rollup.v1.Msg/InitiateWithdrawal",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MsgServiceServer).InitiateWithdrawal(ctx, req.(*InitiateWithdrawalRequest))
+		return srv.(MsgServer).InitiateWithdrawal(ctx, req.(*MsgInitiateWithdrawal))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-var _MsgService_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "rollup.v1.MsgService",
-	HandlerType: (*MsgServiceServer)(nil),
+var _Msg_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "rollup.v1.Msg",
+	HandlerType: (*MsgServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
 			MethodName: "ApplyL1Txs",
-			Handler:    _MsgService_ApplyL1Txs_Handler,
+			Handler:    _Msg_ApplyL1Txs_Handler,
 		},
 		{
 			MethodName: "InitiateWithdrawal",
-			Handler:    _MsgService_InitiateWithdrawal_Handler,
+			Handler:    _Msg_InitiateWithdrawal_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "rollup/v1/tx.proto",
 }
 
-func (m *ApplyL1TxsRequest) Marshal() (dAtA []byte, err error) {
+func (m *MsgApplyL1Txs) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -404,12 +410,12 @@ func (m *ApplyL1TxsRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *ApplyL1TxsRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgApplyL1Txs) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *ApplyL1TxsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgApplyL1Txs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -433,7 +439,7 @@ func (m *ApplyL1TxsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *ApplyL1TxsResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgApplyL1TxsResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -443,12 +449,12 @@ func (m *ApplyL1TxsResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *ApplyL1TxsResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgApplyL1TxsResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *ApplyL1TxsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgApplyL1TxsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -456,7 +462,7 @@ func (m *ApplyL1TxsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *InitiateWithdrawalRequest) Marshal() (dAtA []byte, err error) {
+func (m *MsgInitiateWithdrawal) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -466,12 +472,12 @@ func (m *InitiateWithdrawalRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *InitiateWithdrawalRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgInitiateWithdrawal) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *InitiateWithdrawalRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgInitiateWithdrawal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -517,7 +523,7 @@ func (m *InitiateWithdrawalRequest) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
-func (m *InitiateWithdrawalResponse) Marshal() (dAtA []byte, err error) {
+func (m *MsgInitiateWithdrawalResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -527,12 +533,12 @@ func (m *InitiateWithdrawalResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *InitiateWithdrawalResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *MsgInitiateWithdrawalResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *InitiateWithdrawalResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *MsgInitiateWithdrawalResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -551,7 +557,7 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *ApplyL1TxsRequest) Size() (n int) {
+func (m *MsgApplyL1Txs) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -570,7 +576,7 @@ func (m *ApplyL1TxsRequest) Size() (n int) {
 	return n
 }
 
-func (m *ApplyL1TxsResponse) Size() (n int) {
+func (m *MsgApplyL1TxsResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -579,7 +585,7 @@ func (m *ApplyL1TxsResponse) Size() (n int) {
 	return n
 }
 
-func (m *InitiateWithdrawalRequest) Size() (n int) {
+func (m *MsgInitiateWithdrawal) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -606,7 +612,7 @@ func (m *InitiateWithdrawalRequest) Size() (n int) {
 	return n
 }
 
-func (m *InitiateWithdrawalResponse) Size() (n int) {
+func (m *MsgInitiateWithdrawalResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -621,7 +627,7 @@ func sovTx(x uint64) (n int) {
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *ApplyL1TxsRequest) Unmarshal(dAtA []byte) error {
+func (m *MsgApplyL1Txs) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -644,10 +650,10 @@ func (m *ApplyL1TxsRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: ApplyL1TxsRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgApplyL1Txs: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ApplyL1TxsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgApplyL1Txs: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -735,7 +741,7 @@ func (m *ApplyL1TxsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *ApplyL1TxsResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgApplyL1TxsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -758,10 +764,10 @@ func (m *ApplyL1TxsResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: ApplyL1TxsResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgApplyL1TxsResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ApplyL1TxsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgApplyL1TxsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -785,7 +791,7 @@ func (m *ApplyL1TxsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *InitiateWithdrawalRequest) Unmarshal(dAtA []byte) error {
+func (m *MsgInitiateWithdrawal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -808,10 +814,10 @@ func (m *InitiateWithdrawalRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: InitiateWithdrawalRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgInitiateWithdrawal: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: InitiateWithdrawalRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgInitiateWithdrawal: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1001,7 +1007,7 @@ func (m *InitiateWithdrawalRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *InitiateWithdrawalResponse) Unmarshal(dAtA []byte) error {
+func (m *MsgInitiateWithdrawalResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1024,10 +1030,10 @@ func (m *InitiateWithdrawalResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: InitiateWithdrawalResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: MsgInitiateWithdrawalResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: InitiateWithdrawalResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: MsgInitiateWithdrawalResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
### Background
Closes: https://github.com/polymerdao/monomer/issues/142

As mentioned in the Cosmos SDK [Msg docs](https://docs.cosmos.network/main/build/building-modules/messages-and-queries#msg-services), `"the naming convention is to call the RPC argument Msg<service-rpc-name> and the RPC response Msg<service-rpc-name>Response"`.

The Cosmos SDK [Query docs](https://docs.cosmos.network/main/build/building-modules/messages-and-queries#grpc-queries) don't explicitly state a naming convention, however they use the `Query<service-rpc-name>Request` and `Query<service-rpc-name>Response` notation in their docs and repo.

### Changes
- Updates the linter to use the Cosmos SDK default settings
- Adds comments to each RPC service, msg, and query
- Shortens the RPC service names to Msg and Query
- Updates the following msg/query requests and their corresponding response types:
  - ApplyL1TxsRequest -> MsgApplyL1Txs
  - InitiateWithdrawalRequest -> MsgInitiateWithdrawal
  - GetRequest -> QueryValueRequest
  - SetRequest -> MsgSetValue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction message handling with updated structures for Layer 1 transactions and withdrawal processes.
  - Improved API for querying values, focusing on specific key-value retrieval.

- **Documentation**
  - Added comments to clarify the purpose of configuration objects in modules, enhancing code readability.

- **Refactor**
  - Streamlined naming conventions for services and messages, improving clarity and consistency across the codebase.

- **Tests**
  - Updated test cases to align with new message types, ensuring validation logic remains intact while improving semantic clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->