### PR TITLE
Refactor error handling and update tests

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -110,7 +110,7 @@ func AdaptCosmosTxsToEthTxs(cosmosTxs bfttypes.Txs) (ethtypes.Transactions, erro
 	for _, txBytes := range ethTxsBytes {
 		var tx ethtypes.Transaction
 		if err := tx.UnmarshalBinary(txBytes); err != nil {
-			break
+			return nil, fmt.Errorf("unmarshal binary tx: %v", err)
 		}
 		if !tx.IsDepositTx() {
 			return nil, errors.New("MsgL1Tx contains non-deposit tx")


### PR DESCRIPTION
Refactored the error handling in the `AdaptCosmosTxsToEthTxs` function to return a specific error message when unmarshaling binary transactions fails. Also updated the `builder_test` and `localdb_test` files to reflect the changes.