### PR TITLE
Improve `query` in `requireEthIsMinted` function

### DIFF
--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -256,7 +256,7 @@ func requireEthIsMinted(t *testing.T, appchainClient *bftclient.HTTP) {
 
 	require.NoError(t, err, "search transactions")
 
-	require.True(t, len(result.Txs) > 0, "mint_eth event not found")
+	require.NotEmpty(t, result.Txs, "mint_eth event not found")
 	t.Log("Monomer can mint_eth from L1 user deposits")
 }
 

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -235,7 +235,12 @@ func TestE2E(t *testing.T) {
 }
 
 func requireEthIsMinted(t *testing.T, appchainClient *bftclient.HTTP) {
-	query := "tx.height > 0"
+	query := fmt.Sprintf(
+		"%s.%s='%s'",
+		rolluptypes.EventTypeMintETH,
+		rolluptypes.AttributeKeyL1DepositTxType,
+		rolluptypes.L1UserDepositTxType,
+	)
 	page := 1
 	perPage := 100
 	orderBy := "desc"
@@ -251,17 +256,7 @@ func requireEthIsMinted(t *testing.T, appchainClient *bftclient.HTTP) {
 
 	require.NoError(t, err, "search transactions")
 
-	ethMinted := false
-
-	for _, tx := range result.Txs {
-		for _, event := range tx.TxResult.Events {
-			if event.Type == rolluptypes.EventTypeMintETH {
-				ethMinted = true
-			}
-		}
-	}
-
-	require.True(t, ethMinted, "mint_eth event not found")
+	require.True(t, len(result.Txs) > 0, "mint_eth event not found")
 	t.Log("Monomer can mint_eth from L1 user deposits")
 }
 


### PR DESCRIPTION
Fixes #145

The `query` in the `requireEthIsMinted` function has been updated to retrieve only mint transactions. The previous implementation used a loop to check for the presence of the `mint_eth` event, but this has been replaced with a simple check for the length of the `result.Txs` array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved logic for verifying Ethereum minting events, leading to more accurate checks in transaction results.
	- Streamlined the process for determining the presence of minting events, enhancing overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->