### PR TITLE
Remove x/rollup mint keeper dependency

### DIFF
--- a/doc/docs/learn/create-an-app-with-monomer.md
+++ b/doc/docs/learn/create-an-app-with-monomer.md
@@ -134,7 +134,6 @@ rollup.NewAppModule( // <-- add this block
     rollupkeeper.NewKeeper(
         appCodec,
         runtime.NewKVStoreService(keys[rolluptypes.StoreKey]),
-        &app.MintKeeper,
         app.BankKeeper,
     ),
 ),

--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -100,11 +100,11 @@ func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) error { 
 // mintETH mints ETH to an account where the amount is in wei.
 func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.Int) error { //nolint:gocritic // hugeParam
 	coin := sdk.NewCoin(types.ETH, amount)
-	if err := k.mintKeeper.MintCoins(ctx, sdk.NewCoins(coin)); err != nil {
-		return fmt.Errorf("failed to mint deposit coins from mint module: %v", err)
+	if err := k.bankkeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(coin)); err != nil {
+		return fmt.Errorf("failed to mint deposit coins to the rollup module: %v", err)
 	}
-	if err := k.bankkeeper.SendCoinsFromModuleToAccount(ctx, types.MintModule, addr, sdk.NewCoins(coin)); err != nil {
-		return fmt.Errorf("failed to send deposit coins from mint module to user account %v: %v", addr, err)
+	if err := k.bankkeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, sdk.NewCoins(coin)); err != nil {
+		return fmt.Errorf("failed to send deposit coins from rollup module to user account %v: %v", addr, err)
 	}
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(

--- a/x/rollup/keeper/keeper.go
+++ b/x/rollup/keeper/keeper.go
@@ -4,7 +4,6 @@ import (
 	"cosmossdk.io/core/store"
 	"github.com/cosmos/cosmos-sdk/codec"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
@@ -12,7 +11,6 @@ type Keeper struct {
 	cdc          codec.BinaryCodec
 	storeService store.KVStoreService
 	rollupCfg    *rollup.Config
-	mintKeeper   *mintkeeper.Keeper
 	bankkeeper   bankkeeper.Keeper
 }
 
@@ -20,13 +18,11 @@ func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeService store.KVStoreService,
 	// dependencies
-	mintKeeper *mintkeeper.Keeper,
 	bankKeeper bankkeeper.Keeper,
 ) *Keeper {
 	return &Keeper{
 		cdc:          cdc,
 		storeService: storeService,
-		mintKeeper:   mintKeeper,
 		bankkeeper:   bankKeeper,
 		rollupCfg:    &rollup.Config{},
 	}

--- a/x/rollup/keeper/withdrawals.go
+++ b/x/rollup/keeper/withdrawals.go
@@ -12,14 +12,14 @@ import (
 func (k *Keeper) burnETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.Int) error { //nolint:gocritic // hugeParam
 	coins := sdk.NewCoins(sdk.NewCoin(types.ETH, amount))
 
-	// Transfer the coins to withdraw from the user account to the mint module
-	if err := k.bankkeeper.SendCoinsFromAccountToModule(ctx, addr, types.MintModule, coins); err != nil {
-		return fmt.Errorf("failed to send withdrawal coins from user account %v to mint module: %v", addr, err)
+	// Transfer the coins to withdraw from the user account to the rollup module
+	if err := k.bankkeeper.SendCoinsFromAccountToModule(ctx, addr, types.ModuleName, coins); err != nil {
+		return fmt.Errorf("failed to send withdrawal coins from user account %v to rollup module: %v", addr, err)
 	}
 
-	// Burn the ETH coins from the mint module
-	if err := k.bankkeeper.BurnCoins(ctx, types.MintModule, coins); err != nil {
-		return fmt.Errorf("failed to burn withdrawal coins from mint module: %v", err)
+	// Burn the ETH coins from the rollup module
+	if err := k.bankkeeper.BurnCoins(ctx, types.ModuleName, coins); err != nil {
+		return fmt.Errorf("failed to burn withdrawal coins from rollup module: %v", err)
 	}
 
 	return nil

--- a/x/rollup/module.go
+++ b/x/rollup/module.go
@@ -12,7 +12,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/polymerdao/monomer/gen/rollup/module/v1"
@@ -26,7 +25,6 @@ type ModuleInputs struct {
 
 	Codec        codec.Codec
 	StoreService store.KVStoreService
-	MintKeeper   mintkeeper.Keeper
 	BankKeeper   bankkeeper.Keeper
 }
 
@@ -41,8 +39,8 @@ func init() { //nolint:gochecknoinits
 	appmodule.Register(&modulev1.Module{}, appmodule.Provide(ProvideModule))
 }
 
-func ProvideModule(in ModuleInputs) ModuleOutputs { //nolint:gocritic
-	k := keeper.NewKeeper(in.Codec, in.StoreService, &in.MintKeeper, in.BankKeeper)
+func ProvideModule(in ModuleInputs) ModuleOutputs {
+	k := keeper.NewKeeper(in.Codec, in.StoreService, in.BankKeeper)
 	return ModuleOutputs{
 		Keeper: k,
 		Module: NewAppModule(in.Codec, k),

--- a/x/rollup/types/keys.go
+++ b/x/rollup/types/keys.go
@@ -16,8 +16,7 @@ const (
 
 const (
 	// wrapped Ethers; cannonically bridged from Ethereum
-	ETH        = "ETH"
-	MintModule = "mint"
+	ETH = "ETH"
 	// KeyL1BlockInfo is the key for the L1BlockInfo
 	KeyL1BlockInfo = "L1BlockInfo"
 )


### PR DESCRIPTION
Remove the mint keeper dependency from the x/rollup module and mint to and burn from a rollup module account instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed minting functionality, now streamlined under the rollup module.
	- Enhanced token management capabilities within the rollup module.
	
- **Bug Fixes**
	- Updated error messaging for operations related to token minting and burning for clarity.
	
- **Documentation**
	- Updated documentation to reflect changes in module interactions and functionality related to token management and minting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->