### PR TITLE
Fix bug for nonce event attribute population in builder.go

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -267,8 +267,9 @@ func (b *Builder) parseWithdrawalMessages(
 				}
 
 				// Populate the nonce in the tx event attributes.
-				for _, event := range execTxResult.GetEvents() {
-					if event.GetType() == rolluptypes.EventTypeWithdrawalInitiated {
+				for i := range execTxResult.Events {
+					event := &execTxResult.Events[i] // Get a pointer to the event, so we can modify it.
+					if event.Type == rolluptypes.EventTypeWithdrawalInitiated {
 						event.Attributes = append(event.Attributes, abcitypes.EventAttribute{
 							Key:   rolluptypes.AttributeKeyNonce,
 							Value: hexutil.Encode(nonce.Bytes()),


### PR DESCRIPTION
Changed the event iteration to use pointers, ensuring modifications to event attributes are correctly applied. This addresses a bug where nonce attributes were not properly appended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved processing of withdrawal events for enhanced efficiency and clarity.
	- Direct modification of event attributes, including the ability to append the nonce attribute to withdrawal events.
- **Bug Fixes**
	- Ensured only events of type `EventTypeWithdrawalInitiated` are processed for nonce assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->