### PR TITLE
Add x/rollup integration test

### DIFF
--- a/tests/integration/rollup/rollup_test.go
+++ b/tests/integration/rollup/rollup_test.go
@@ -22,7 +22,7 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
-	rolluptestutils "github.com/polymerdao/monomer/testutils"
+	monomertestutils "github.com/polymerdao/monomer/testutils"
 	"github.com/polymerdao/monomer/x/rollup"
 	rollupkeeper "github.com/polymerdao/monomer/x/rollup/keeper"
 	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
@@ -33,11 +33,11 @@ func TestRollup(t *testing.T) {
 	integrationApp, bankKeeper := setupIntegrationApp(t)
 
 	monomerSigner := "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh"
-	l1AttributesTx, depositTx, _ := rolluptestutils.GenerateEthTxs(t)
+	l1AttributesTx, depositTx, _ := monomertestutils.GenerateEthTxs(t)
 	l1WithdrawalAddr := common.HexToAddress("0x12345").String()
 
-	l1AttributesTxBz := rolluptestutils.TxToBytes(t, l1AttributesTx)
-	depositTxBz := rolluptestutils.TxToBytes(t, depositTx)
+	l1AttributesTxBz := monomertestutils.TxToBytes(t, l1AttributesTx)
+	depositTxBz := monomertestutils.TxToBytes(t, depositTx)
 
 	depositAmount := depositTx.Value()
 	var userAddr sdk.AccAddress = depositTx.To().Bytes()

--- a/tests/integration/rollup/rollup_test.go
+++ b/tests/integration/rollup/rollup_test.go
@@ -1,0 +1,139 @@
+package rollup_test
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/log"
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil/integration"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ethereum/go-ethereum/common"
+	rolluptestutils "github.com/polymerdao/monomer/testutils"
+	"github.com/polymerdao/monomer/x/rollup"
+	rollupkeeper "github.com/polymerdao/monomer/x/rollup/keeper"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollup(t *testing.T) {
+	integrationApp, bankKeeper := setupIntegrationApp(t)
+
+	monomerSigner := "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh"
+	l1AttributesTx, depositTx, _ := rolluptestutils.GenerateEthTxs(t)
+	l1WithdrawalAddr := common.HexToAddress("0x12345").String()
+
+	l1AttributesTxBz := rolluptestutils.TxToBytes(t, l1AttributesTx)
+	depositTxBz := rolluptestutils.TxToBytes(t, depositTx)
+
+	depositAmount := depositTx.Value()
+	var userAddr sdk.AccAddress = depositTx.To().Bytes()
+
+	// query the user's ETH balance and assert it's zero
+	require.Equal(t, math.ZeroInt(), bankKeeper.GetBalance(integrationApp.Context(), userAddr, rolluptypes.ETH).Amount)
+
+	// send an invalid MsgApplyL1Txs and assert error
+	_, err := integrationApp.RunMsg(&rolluptypes.MsgApplyL1Txs{
+		TxBytes:     [][]byte{l1AttributesTxBz, l1AttributesTxBz},
+		FromAddress: monomerSigner,
+	})
+	require.Error(t, err)
+
+	// send a successful MsgApplyL1Txs and mint ETH to user
+	_, err = integrationApp.RunMsg(&rolluptypes.MsgApplyL1Txs{
+		TxBytes:     [][]byte{l1AttributesTxBz, depositTxBz},
+		FromAddress: monomerSigner,
+	})
+	require.NoError(t, err)
+
+	// query the user's ETH balance and assert it's equal to the deposit amount
+	require.Equal(t, depositAmount, bankKeeper.GetBalance(integrationApp.Context(), userAddr, rolluptypes.ETH).Amount.BigInt())
+
+	// try to withdraw more than deposited and assert error
+	_, err = integrationApp.RunMsg(&rolluptypes.MsgInitiateWithdrawal{
+		Sender:   userAddr.String(),
+		Target:   l1WithdrawalAddr,
+		Value:    math.NewIntFromBigInt(depositAmount).Add(math.OneInt()),
+		GasLimit: new(big.Int).SetUint64(100_000_000).Bytes(),
+		Data:     []byte{0x01, 0x02, 0x03},
+	})
+	require.Error(t, err)
+
+	// send a successful MsgInitiateWithdrawal
+	_, err = integrationApp.RunMsg(&rolluptypes.MsgInitiateWithdrawal{
+		Sender:   userAddr.String(),
+		Target:   l1WithdrawalAddr,
+		Value:    math.NewIntFromBigInt(depositAmount),
+		GasLimit: new(big.Int).SetUint64(100_000_000).Bytes(),
+		Data:     []byte{0x01, 0x02, 0x03},
+	})
+	require.NoError(t, err)
+
+	// query the user's ETH balance and assert it's zero
+	require.Equal(t, math.ZeroInt(), bankKeeper.GetBalance(integrationApp.Context(), userAddr, rolluptypes.ETH).Amount)
+}
+
+func setupIntegrationApp(t *testing.T) (*integration.App, bankkeeper.BaseKeeper) {
+	encodingCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, bank.AppModuleBasic{}, rollup.AppModuleBasic{})
+	keys := storetypes.NewKVStoreKeys(authtypes.StoreKey, banktypes.StoreKey, rolluptypes.StoreKey)
+	authority := authtypes.NewModuleAddress("gov").String()
+
+	logger := log.NewTestLogger(t)
+
+	cms := integration.CreateMultiStore(keys, logger)
+
+	accountKeeper := authkeeper.NewAccountKeeper(
+		encodingCfg.Codec,
+		runtime.NewKVStoreService(keys[authtypes.StoreKey]),
+		authtypes.ProtoBaseAccount,
+		map[string][]string{rolluptypes.ModuleName: {authtypes.Minter, authtypes.Burner}},
+		addresscodec.NewBech32Codec("cosmos"),
+		"cosmos",
+		authority,
+	)
+	bankKeeper := bankkeeper.NewBaseKeeper(
+		encodingCfg.Codec,
+		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
+		accountKeeper,
+		map[string]bool{},
+		authority,
+		logger,
+	)
+	rollupKeeper := rollupkeeper.NewKeeper(
+		encodingCfg.Codec,
+		runtime.NewKVStoreService(keys[rolluptypes.StoreKey]),
+		bankKeeper,
+	)
+
+	authModule := auth.NewAppModule(encodingCfg.Codec, accountKeeper, authsims.RandomGenesisAccounts, nil)
+	bankModule := bank.NewAppModule(encodingCfg.Codec, bankKeeper, accountKeeper, nil)
+	rollupModule := rollup.NewAppModule(encodingCfg.Codec, rollupKeeper)
+
+	integrationApp := integration.NewIntegrationApp(
+		sdk.NewContext(cms, cmtproto.Header{}, false, logger),
+		logger,
+		keys,
+		encodingCfg.Codec,
+		map[string]appmodule.AppModule{
+			authtypes.ModuleName:   authModule,
+			banktypes.ModuleName:   bankModule,
+			rolluptypes.ModuleName: rollupModule,
+		},
+	)
+	rolluptypes.RegisterMsgServer(integrationApp.MsgServiceRouter(), rollupkeeper.NewMsgServerImpl(rollupKeeper))
+
+	return integrationApp, bankKeeper
+}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -80,6 +80,12 @@ func GenerateEthTxs(t *testing.T) (*gethtypes.Transaction, *gethtypes.Transactio
 	return l1InfoTx, depositTx, cosmosEthTx
 }
 
+func TxToBytes(t *testing.T, tx *gethtypes.Transaction) []byte {
+	txBytes, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	return txBytes
+}
+
 func cosmosTxsFromEthTxs(t *testing.T, l1InfoTx *gethtypes.Transaction, depositTxs, cosmosEthTxs []*gethtypes.Transaction) bfttypes.Txs {
 	l1InfoTxBytes, err := l1InfoTx.MarshalBinary()
 	require.NoError(t, err)

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -20,14 +20,10 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 	// The only constraint for a contract creation tx is that it must be a non-system DepositTx with no To field
 	contractCreationTx := gethtypes.NewTx(&gethtypes.DepositTx{})
 
-	l1AttributesTxBz, err := l1AttributesTx.MarshalBinary()
-	s.Require().NoError(err)
-	depositTxBz, err := depositTx.MarshalBinary()
-	s.Require().NoError(err)
-	cosmosEthTxBz, err := cosmosEthTx.MarshalBinary()
-	s.Require().NoError(err)
-	contractCreationTxBz, err := contractCreationTx.MarshalBinary()
-	s.Require().NoError(err)
+	l1AttributesTxBz := testutils.TxToBytes(s.T(), l1AttributesTx)
+	depositTxBz := testutils.TxToBytes(s.T(), depositTx)
+	cosmosEthTxBz := testutils.TxToBytes(s.T(), cosmosEthTx)
+	contractCreationTxBz := testutils.TxToBytes(s.T(), contractCreationTx)
 	invalidTxBz := []byte("invalid tx bytes")
 
 	tests := map[string]struct {
@@ -98,8 +94,7 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 			}
 			s.mockMintETH()
 
-			var resp *types.MsgApplyL1TxsResponse
-			resp, err = keeper.NewMsgServerImpl(s.rollupKeeper).ApplyL1Txs(s.ctx, &types.MsgApplyL1Txs{
+			resp, err := keeper.NewMsgServerImpl(s.rollupKeeper).ApplyL1Txs(s.ctx, &types.MsgApplyL1Txs{
 				TxBytes: test.txBytes,
 			})
 

--- a/x/rollup/tests/integration/rollup_test.go
+++ b/x/rollup/tests/integration/rollup_test.go
@@ -1,4 +1,4 @@
-package rollup_test
+package integration_test
 
 import (
 	"math/big"


### PR DESCRIPTION
Adds an integration test to assert the full deposit to withdrawal user flow with a real bank keeper and testapp.

The test follows the Cosmos SDK [integration test standards](https://docs.cosmos.network/v0.50/build/building-modules/testing#integration-tests) and stores the test in the `x/rollup/tests/integration` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new Makefile targets for mock generation to enhance testing capabilities.
  - Added integration and unit tests for the rollup module, validating key functionalities like transaction processing and withdrawals.
  - New `BankKeeper` interface defined to standardize bank operations within the rollup module.

- **Bug Fixes**
  - Enhanced error handling logic in transaction processing functions.

- **Refactor**
  - Renamed functions for consistency with Go naming conventions.
  - Simplified function logic and parameters to improve code clarity.

- **Tests**
  - Established comprehensive test suites for various functionalities within the rollup module, ensuring robust error handling and performance.

- **Chores**
  - Added mock implementations for better unit testing of components relying on the `BankKeeper` interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->