### PR TITLE
Add Builder Withdrawal Tests and Refactor Related Components

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -3,8 +3,10 @@ package builder_test
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 
+	"cosmossdk.io/math"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
 	bfttypes "github.com/cometbft/cometbft/types"
@@ -19,10 +21,23 @@ import (
 	"github.com/polymerdao/monomer/evm"
 	"github.com/polymerdao/monomer/genesis"
 	"github.com/polymerdao/monomer/mempool"
+	"github.com/polymerdao/monomer/monomerdb/localdb"
 	"github.com/polymerdao/monomer/testapp"
 	"github.com/polymerdao/monomer/testutils"
+	"github.com/polymerdao/monomer/utils"
+	"github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
+
+type testEnvironment struct {
+	app        *testapp.App
+	g          *genesis.Genesis
+	pool       *mempool.Pool
+	blockStore *localdb.DB
+	txStore    txstore.TxStore
+	ethstatedb state.Database
+	eventBus   *bfttypes.EventBus
+}
 
 type queryAll struct{}
 
@@ -80,74 +95,51 @@ func TestBuild(t *testing.T) {
 
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
+			// +1 because we want it to be buffered even when mempool and inclusion list are empty.
+			subChannelLen := len(test.mempool) + len(test.inclusionList) + 1
+			env, subscription := setupTestEnvironmentAndSubscribe(t, subChannelLen)
+
 			inclusionListTxs := append([][]byte{testutils.GenerateBlock(t).Txs[0]}, testapp.ToTxs(t, test.inclusionList)...)
 			mempoolTxs := testapp.ToTxs(t, test.mempool)
 
-			pool := mempool.New(testutils.NewMemDB(t))
 			for _, tx := range mempoolTxs {
-				require.NoError(t, pool.Enqueue(tx))
+				require.NoError(t, env.pool.Enqueue(tx))
 			}
-			blockStore := testutils.NewLocalMemDB(t)
-			txStore := txstore.NewTxStore(testutils.NewCometMemDB(t))
-			ethstatedb := testutils.NewEthStateDB(t)
-
-			var chainID monomer.ChainID
-			app := testapp.NewTest(t, chainID.String())
-			g := &genesis.Genesis{
-				ChainID:  chainID,
-				AppState: testapp.MakeGenesisAppState(t, app),
-			}
-
-			eventBus := bfttypes.NewEventBus()
-			require.NoError(t, eventBus.Start())
-			t.Cleanup(func() {
-				require.NoError(t, eventBus.Stop())
-			})
-			// +1 because we want it to be buffered even when mempool and inclusion list are empty.
-			subChannelLen := len(test.mempool) + len(test.inclusionList) + 1
-			subscription, err := eventBus.Subscribe(context.Background(), "test", &queryAll{}, subChannelLen)
-			require.NoError(t, err)
-
-			require.NoError(t, g.Commit(context.Background(), app, blockStore, ethstatedb))
 
 			b := builder.New(
-				pool,
-				app,
-				blockStore,
-				txStore,
-				eventBus,
-				g.ChainID,
-				ethstatedb,
+				env.pool,
+				env.app,
+				env.blockStore,
+				env.txStore,
+				env.eventBus,
+				env.g.ChainID,
+				env.ethstatedb,
 			)
 
 			payload := &builder.Payload{
 				InjectedTransactions: bfttypes.ToTxs(inclusionListTxs),
 				GasLimit:             0,
-				Timestamp:            g.Time + 1,
+				Timestamp:            env.g.Time + 1,
 				NoTxPool:             test.noTxPool,
 			}
-			preBuildInfo, err := app.Info(context.Background(), &abcitypes.RequestInfo{})
-			require.NoError(t, err)
-			builtBlock, err := b.Build(context.Background(), payload)
-			require.NoError(t, err)
-			postBuildInfo, err := app.Info(context.Background(), &abcitypes.RequestInfo{})
-			require.NoError(t, err)
+
+			builtBlock, preBuildInfo, postBuildInfo := buildBlock(t, b, env.app, payload)
 
 			// Application.
 			{
 				height := uint64(postBuildInfo.GetLastBlockHeight())
-				app.StateContains(t, height, test.inclusionList)
+				env.app.StateContains(t, height, test.inclusionList)
 				if test.noTxPool {
-					app.StateDoesNotContain(t, height, test.mempool)
+					env.app.StateDoesNotContain(t, height, test.mempool)
 				} else {
-					app.StateContains(t, height, test.mempool)
+					env.app.StateContains(t, height, test.mempool)
 				}
 			}
 
 			// Block store.
-			genesisHeader, err := blockStore.BlockByHeight(uint64(preBuildInfo.GetLastBlockHeight()))
+			genesisHeader, err := env.blockStore.BlockByHeight(uint64(preBuildInfo.GetLastBlockHeight()))
 			require.NoError(t, err)
-			gotBlock, err := blockStore.HeadBlock()
+			gotBlock, err := env.blockStore.HeadBlock()
 			require.NoError(t, err)
 			allTxs := append([][]byte{}, inclusionListTxs...)
 			if !test.noTxPool {
@@ -156,7 +148,7 @@ func TestBuild(t *testing.T) {
 
 			ethStateRoot := gotBlock.Header.StateRoot
 			header := &monomer.Header{
-				ChainID:    g.ChainID,
+				ChainID:    env.g.ChainID,
 				Height:     uint64(postBuildInfo.GetLastBlockHeight()),
 				Time:       payload.Timestamp,
 				ParentHash: genesisHeader.Header.Hash,
@@ -165,11 +157,10 @@ func TestBuild(t *testing.T) {
 			}
 			wantBlock, err := monomer.MakeBlock(header, bfttypes.ToTxs(allTxs))
 			require.NoError(t, err)
-			require.Equal(t, wantBlock, builtBlock)
-			require.Equal(t, wantBlock, gotBlock)
+			verifyBlockContent(t, wantBlock, gotBlock, builtBlock)
 
 			// Eth state db.
-			ethState, err := state.New(ethStateRoot, ethstatedb, nil)
+			ethState, err := state.New(ethStateRoot, env.ethstatedb, nil)
 			require.NoError(t, err)
 			appHash, err := getAppHashFromEVM(ethState, header)
 			require.NoError(t, err)
@@ -177,31 +168,14 @@ func TestBuild(t *testing.T) {
 
 			// Tx store and event bus.
 			for i, tx := range wantBlock.Txs {
-				checkTxResult := func(got abcitypes.TxResult) {
-					// We don't check the full result, which would be difficult and a bit overkill.
-					// We only verify that the main info is correct.
-					require.Equal(t, uint32(i), got.Index)
-					require.Equal(t, wantBlock.Header.Height, uint64(got.Height))
-					require.Equal(t, tx, bfttypes.Tx(got.Tx))
-				}
-
 				// Tx store.
-				got, err := txStore.Get(tx.Hash())
+				got, err := env.txStore.Get(tx.Hash())
 				require.NoError(t, err)
-				checkTxResult(*got)
+				checkTxResult(t, got, wantBlock, i, tx)
 
 				// Event bus.
-				select {
-				case event, ok := <-subscription.Out():
-					if !ok {
-						require.FailNow(t, "event channel closed unexpectedly")
-					}
-					data := event.Data()
-					require.IsType(t, bfttypes.EventDataTx{}, data)
-					checkTxResult(data.(bfttypes.EventDataTx).TxResult)
-				case <-subscription.Canceled():
-					require.FailNow(t, "subscription channel closed unexpectedly")
-				}
+				eventData := getEventData(t, subscription)
+				checkTxResult(t, &eventData.TxResult, wantBlock, i, tx)
 			}
 			require.NoError(t, subscription.Err())
 		})
@@ -209,51 +183,33 @@ func TestBuild(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	pool := mempool.New(testutils.NewMemDB(t))
-	blockStore := testutils.NewLocalMemDB(t)
-	txStore := txstore.NewTxStore(testutils.NewCometMemDB(t))
-	ethstatedb := testutils.NewEthStateDB(t)
-
-	var chainID monomer.ChainID
-	app := testapp.NewTest(t, chainID.String())
-	g := &genesis.Genesis{
-		ChainID:  chainID,
-		AppState: testapp.MakeGenesisAppState(t, app),
-	}
-
-	eventBus := bfttypes.NewEventBus()
-	require.NoError(t, eventBus.Start())
-	t.Cleanup(func() {
-		require.NoError(t, eventBus.Stop())
-	})
-
-	require.NoError(t, g.Commit(context.Background(), app, blockStore, ethstatedb))
-	genesisHeader, err := blockStore.HeadHeader()
+	env := setupTestEnvironment(t)
+	genesisHeader, err := env.blockStore.HeadHeader()
 	require.NoError(t, err)
 
 	b := builder.New(
-		pool,
-		app,
-		blockStore,
-		txStore,
-		eventBus,
-		g.ChainID,
-		ethstatedb,
+		env.pool,
+		env.app,
+		env.blockStore,
+		env.txStore,
+		env.eventBus,
+		env.g.ChainID,
+		env.ethstatedb,
 	)
 
 	kvs := map[string]string{
 		"test": "test",
 	}
 	block, err := b.Build(context.Background(), &builder.Payload{
-		Timestamp:            g.Time + 1,
+		Timestamp:            env.g.Time + 1,
 		InjectedTransactions: bfttypes.ToTxs(append([][]byte{testutils.GenerateBlock(t).Txs[0]}, testapp.ToTxs(t, kvs)...)),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, block)
-	require.NoError(t, blockStore.UpdateLabels(block.Header.Hash, block.Header.Hash, block.Header.Hash))
+	require.NoError(t, env.blockStore.UpdateLabels(block.Header.Hash, block.Header.Hash, block.Header.Hash))
 
 	// Eth state db before rollback.
-	ethState, err := state.New(block.Header.StateRoot, ethstatedb, nil)
+	ethState, err := state.New(block.Header.StateRoot, env.ethstatedb, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, ethState.GetStorageRoot(contracts.L2ApplicationStateRootProviderAddr), gethtypes.EmptyRootHash)
 
@@ -262,7 +218,7 @@ func TestRollback(t *testing.T) {
 
 	// Application.
 	for k := range kvs {
-		resp, err := app.Query(context.Background(), &abcitypes.RequestQuery{
+		resp, err := env.app.Query(context.Background(), &abcitypes.RequestQuery{
 			Data: []byte(k),
 		})
 		require.NoError(t, err)
@@ -270,19 +226,19 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Block store.
-	height, err := blockStore.Height()
+	height, err := env.blockStore.Height()
 	require.NoError(t, err)
 	require.Equal(t, genesisHeader.Height, height)
 	// We trust that the other parts of a block store rollback were done as well.
 
 	// Eth state db after rollback.
-	ethState, err = state.New(genesisHeader.StateRoot, ethstatedb, nil)
+	ethState, err = state.New(genesisHeader.StateRoot, env.ethstatedb, nil)
 	require.NoError(t, err)
 	require.Equal(t, ethState.GetStorageRoot(contracts.L2ApplicationStateRootProviderAddr), gethtypes.EmptyRootHash)
 
 	// Tx store.
 	for _, tx := range bfttypes.ToTxs(testapp.ToTxs(t, kvs)) {
-		result, err := txStore.Get(tx.Hash())
+		result, err := env.txStore.Get(tx.Hash())
 		require.NoError(t, err)
 		require.Nil(t, result)
 	}
@@ -306,4 +262,242 @@ func getAppHashFromEVM(ethState *state.StateDB, header *monomer.Header) (common.
 	}
 
 	return appHash, nil
+}
+
+func TestBuildRollupTxs(t *testing.T) {
+	// 3 for L1 attribute, deposit, and withdrawal txs, plus 1 as buffer
+	subChannelLen := 4
+	env, subscription := setupTestEnvironmentAndSubscribe(t, subChannelLen)
+	generatedBlock := testutils.GenerateBlock(t)
+
+	// Get the L1 info & deposit transactions (combined)
+	depositTxs := generatedBlock.Txs[0]
+
+	ethTxs, err := monomer.AdaptCosmosTxsToEthTxs(bfttypes.Txs{depositTxs})
+	require.NoError(t, err)
+	require.Len(t, ethTxs, 2, "Expected two Ethereum transactions: L1 attribute and deposit tx, got %d", len(ethTxs))
+
+	depositTxETH := ethTxs[1]
+	require.NotNil(t, depositTxETH.Value())
+	require.NotNil(t, depositTxETH.To(), "Deposit transaction must have a 'to' address")
+
+	cosmAddr := utils.EvmToCosmosAddress(*depositTxETH.To())
+	withdrawalTx := testapp.ToWithdrawalTx(
+		t,
+		cosmAddr.String(),
+		common.HexToAddress("0x12345abcde").String(),
+		math.NewIntFromBigInt(depositTxETH.Value()),
+	)
+
+	b := builder.New(
+		env.pool,
+		env.app,
+		env.blockStore,
+		env.txStore,
+		env.eventBus,
+		env.g.ChainID,
+		env.ethstatedb,
+	)
+
+	// Prepare the payload
+	txs := bfttypes.Txs{depositTxs, withdrawalTx}
+	payload := &builder.Payload{
+		InjectedTransactions: txs,
+		GasLimit:             1000000000000,
+		Timestamp:            env.g.Time + 1,
+		NoTxPool:             true,
+	}
+
+	// Build a block with the payload
+	builtBlock, preBuildInfo, postBuildInfo := buildBlock(t, b, env.app, payload)
+
+	// Test deposit was received
+	checkDepositTxResult(t, env.txStore, depositTxs, fmt.Sprintf("%sETH", depositTxETH.Value().String()), cosmAddr.String())
+
+	withdrawalTxResult, err := env.txStore.Get(bfttypes.Tx(withdrawalTx).Hash())
+	require.NoError(t, err)
+	require.NotNil(t, withdrawalTxResult)
+	require.Truef(t, withdrawalTxResult.Result.IsOK(), "Expected the withdrawal transaction to be successful, but it failed")
+
+	// Verify block creation
+	genesisBlock, err := env.blockStore.BlockByHeight(uint64(preBuildInfo.GetLastBlockHeight()))
+	require.NoError(t, err)
+	gotBlock, err := env.blockStore.HeadBlock()
+	require.NoError(t, err)
+
+	ethStateRoot := gotBlock.Header.StateRoot
+	header := monomer.Header{
+		ChainID:    env.g.ChainID,
+		Height:     uint64(postBuildInfo.GetLastBlockHeight()),
+		Time:       payload.Timestamp,
+		ParentHash: genesisBlock.Header.Hash,
+		StateRoot:  ethStateRoot,
+		GasLimit:   payload.GasLimit,
+	}
+	wantBlock, err := monomer.MakeBlock(&header, txs)
+	require.NoError(t, err)
+	verifyBlockContent(t, wantBlock, gotBlock, builtBlock)
+
+	// We expect two transactions: one combined transaction (l1InfoTx + depositTxs) and one withdrawal transaction (withdrawalTx).
+	require.Equal(t, 2, builtBlock.Txs.Len(), "Expected the built block to contain 2 transactions: depositTxs and withdrawalTx")
+
+	// Test parseWithdrawalMessages
+	checkWithdrawalTxResult(t, withdrawalTxResult)
+
+	expectedStateRoot := wantBlock.Header.StateRoot
+	gotStateRoot := gotBlock.Header.StateRoot
+	require.Equal(t, expectedStateRoot, gotStateRoot, "Expected the built block to contain state root hash")
+
+	// Verify deposit and withdrawal msg event
+	expectedEvents := []string{
+		"/rollup.v1.MsgApplyL1Txs",
+		"/rollup.v1.MsgInitiateWithdrawal",
+	}
+
+	for _, expectedEvent := range expectedEvents {
+		eventData := getEventData(t, subscription)
+		require.Equal(t, expectedEvent, eventData.Result.Events[0].Attributes[0].Value,
+			"Unexpected event type")
+	}
+}
+
+func setupTestEnvironment(t *testing.T) testEnvironment {
+	var chainID monomer.ChainID
+	pool := mempool.New(testutils.NewMemDB(t))
+	blockStore := testutils.NewLocalMemDB(t)
+	txStore := txstore.NewTxStore(testutils.NewCometMemDB(t))
+	ethstatedb := testutils.NewEthStateDB(t)
+
+	app := testapp.NewTest(t, chainID.String())
+	g := &genesis.Genesis{
+		ChainID:  chainID,
+		AppState: testapp.MakeGenesisAppState(t, app),
+	}
+
+	eventBus := bfttypes.NewEventBus()
+	require.NoError(t, eventBus.Start())
+	t.Cleanup(func() {
+		require.NoError(t, eventBus.Stop())
+	})
+
+	require.NoError(t, g.Commit(context.Background(), app, blockStore, ethstatedb))
+
+	return testEnvironment{
+		app:        app,
+		g:          g,
+		pool:       pool,
+		blockStore: blockStore,
+		txStore:    txStore,
+		ethstatedb: ethstatedb,
+		eventBus:   eventBus,
+	}
+}
+
+func subscribeToEventBus(t *testing.T, eventBus *bfttypes.EventBus, subChannelLen int) bfttypes.Subscription {
+	subscription, err := eventBus.Subscribe(context.Background(), "test", &queryAll{}, subChannelLen)
+	require.NoError(t, err)
+	return subscription
+}
+
+func setupTestEnvironmentAndSubscribe(t *testing.T, subChannelLen int) (testEnvironment, bfttypes.Subscription) {
+	env := setupTestEnvironment(t)
+	subscription := subscribeToEventBus(t, env.eventBus, subChannelLen)
+	return env, subscription
+}
+
+func buildBlock(
+	t *testing.T,
+	b *builder.Builder,
+	app monomer.Application,
+	payload *builder.Payload,
+) (*monomer.Block, *abcitypes.ResponseInfo, *abcitypes.ResponseInfo) {
+	preBuildInfo, err := app.Info(context.Background(), &abcitypes.RequestInfo{})
+	require.NoError(t, err)
+
+	builtBlock, err := b.Build(context.Background(), payload)
+	require.NoError(t, err)
+
+	postBuildInfo, err := app.Info(context.Background(), &abcitypes.RequestInfo{})
+	require.NoError(t, err)
+
+	return builtBlock, preBuildInfo, postBuildInfo
+}
+
+func verifyBlockContent(t *testing.T, wantBlock, gotBlock, builtBlock *monomer.Block) {
+	require.Equal(t, wantBlock, builtBlock)
+	require.Equal(t, wantBlock, gotBlock)
+}
+
+func checkTxResult(t *testing.T, got *abcitypes.TxResult, wantBlock *monomer.Block, i int, tx bfttypes.Tx) {
+	require.Equal(t, uint32(i), got.Index)
+	require.Equal(t, wantBlock.Header.Height, uint64(got.Height))
+	require.Equal(t, tx, bfttypes.Tx(got.Tx))
+}
+
+func checkWithdrawalTxResult(t *testing.T, withdrawalTxResult *abcitypes.TxResult) {
+	var withdrawalEvent *abcitypes.Event
+	for i := range withdrawalTxResult.Result.Events {
+		event := &withdrawalTxResult.Result.Events[i]
+		if event.Type == types.EventTypeWithdrawalInitiated {
+			withdrawalEvent = event
+			break
+		}
+	}
+	require.NotNil(t, withdrawalEvent, "Expected to find a withdrawal_initiated event")
+	require.NotEmpty(t, withdrawalEvent.Attributes, "Expected attributes to not be empty for withdrawal event")
+
+	var nonceAttribute *abcitypes.EventAttribute
+	for i := range withdrawalEvent.Attributes {
+		attribute := &withdrawalEvent.Attributes[i]
+		if attribute.Key == types.AttributeKeyNonce {
+			nonceAttribute = attribute
+			break
+		}
+	}
+	require.NotNil(t, nonceAttribute, "Expected to find a withdrawal nonce attribute")
+	require.NotEmpty(t, nonceAttribute.Value, "Withdrawal nonce value should not be empty")
+}
+
+func checkDepositTxResult(t *testing.T, txStore txstore.TxStore, depositTx bfttypes.Tx, expectedDepositAmount, cosmAddr string) {
+	const (
+		receiverAttributeIndex = 1
+		valueAttributeIndex    = 2
+	)
+	hash := depositTx.Hash()
+	depositTxResult, err := txStore.Get(hash)
+	require.NoError(t, err, "Failed to get deposit transaction result")
+
+	var MintEthEvent *abcitypes.Event
+	for i, event := range depositTxResult.Result.Events {
+		if event.Type == types.EventTypeMintETH {
+			MintEthEvent = &depositTxResult.Result.Events[i]
+			break
+		}
+	}
+
+	require.NotNil(t, MintEthEvent, "Expected to find the second coin_received event")
+
+	actualReceiver := MintEthEvent.Attributes[receiverAttributeIndex].Value
+	actualDepositAmount := MintEthEvent.Attributes[valueAttributeIndex].Value
+
+	decimalValue := new(big.Int)
+	decimalValue.SetString(actualDepositAmount[2:], 16)
+
+	actualDepositAmount = fmt.Sprintf("%sETH", decimalValue.String())
+
+	require.Equal(t, cosmAddr, actualReceiver, "Receiver address mismatch")
+	require.Equal(t, expectedDepositAmount, actualDepositAmount, "Deposit amount mismatch")
+}
+
+func getEventData(t *testing.T, subscription bfttypes.Subscription) bfttypes.EventDataTx {
+	select {
+	case event, ok := <-subscription.Out():
+		require.True(t, ok, "Event channel closed unexpectedly")
+		data, ok := event.Data().(bfttypes.EventDataTx)
+		require.True(t, ok, "Expected EventDataTx type")
+		return data
+	case <-subscription.Canceled():
+		require.FailNow(t, "Subscription channel closed unexpectedly")
+		return bfttypes.EventDataTx{} // This line will never be reached due to FailNow, but it's needed for compilation
+	}
 }

--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -45,7 +45,7 @@ func TestABCI(t *testing.T) {
 	// Build bock with tx.
 	height := int64(1)
 	_, err = app.FinalizeBlock(context.Background(), &abcitypes.RequestFinalizeBlock{
-		Txs:    [][]byte{testapp.ToTx(t, k, v)},
+		Txs:    [][]byte{testapp.ToTestTx(t, k, v)},
 		Height: height,
 	})
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestBroadcastTx(t *testing.T) {
 	broadcastTxAPI := comet.NewBroadcastTxAPI(app, mpool)
 
 	// Success case.
-	tx := testapp.ToTx(t, "k1", "v1")
+	tx := testapp.ToTestTx(t, "k1", "v1")
 	result, err := broadcastTxAPI.BroadcastTx(&jsonrpctypes.Context{}, tx)
 	require.NoError(t, err)
 	// We trust that the other fields are set correctly.

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -139,7 +139,7 @@ func containsAttributesTx(t *testing.T, stack *e2e.StackConfig) {
 }
 
 func cometBFTtx(t *testing.T, stack *e2e.StackConfig) {
-	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
+	txBytes := testapp.ToTestTx(t, "userTxKey", "userTxValue")
 	bftTx := bfttypes.Tx(txBytes)
 
 	putTx, err := stack.L2Client.BroadcastTxAsync(stack.Ctx, txBytes)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/ethereum-optimism/optimism v1.7.4
 	github.com/ethereum/go-ethereum v1.13.11
 	github.com/fxamacker/cbor/v2 v2.5.0
+	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -130,7 +131,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/glog v1.2.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 // indirect

--- a/integrations/integrations_test.go
+++ b/integrations/integrations_test.go
@@ -86,7 +86,7 @@ func TestStartCommandHandler(t *testing.T) {
 	require.NoError(t, err, "could not create CometBFT client")
 	t.Log("CometBFT client created", "bftClient", bftClient)
 
-	txBytes := testapp.ToTx(t, "userTxKey", "userTxValue")
+	txBytes := testapp.ToTestTx(t, "userTxKey", "userTxValue")
 	bftTx := bfttypes.Tx(txBytes)
 
 	putTx, err := bftClient.BroadcastTxAsync(ctx, txBytes)

--- a/monomerdb/localdb/localdb_test.go
+++ b/monomerdb/localdb/localdb_test.go
@@ -101,14 +101,14 @@ func testHeadBlock(t *testing.T, db *localdb.DB, block *monomer.Block) {
 
 func TestRollback(t *testing.T) {
 	db := testutils.NewLocalMemDB(t)
-	block := testutils.GenerateBlockWithParentAndTxs(t, &monomer.Header{}, testapp.ToTx(t, "k", "v"))
+	block := testutils.GenerateBlockWithParentAndTxs(t, &monomer.Header{}, testapp.ToTestTx(t, "k", "v"))
 	require.NoError(t, db.AppendBlock(block))
 	require.NoError(t, db.UpdateLabels(block.Header.Hash, block.Header.Hash, block.Header.Hash))
 
-	block2 := testutils.GenerateBlockWithParentAndTxs(t, block.Header, testapp.ToTx(t, "k2", "v2"))
+	block2 := testutils.GenerateBlockWithParentAndTxs(t, block.Header, testapp.ToTestTx(t, "k2", "v2"))
 	require.NoError(t, db.AppendBlock(block2))
 
-	block3 := testutils.GenerateBlockWithParentAndTxs(t, block2.Header, testapp.ToTx(t, "k3", "v3"))
+	block3 := testutils.GenerateBlockWithParentAndTxs(t, block2.Header, testapp.ToTestTx(t, "k3", "v3"))
 	require.NoError(t, db.AppendBlock(block3))
 
 	require.NoError(t, db.UpdateLabels(block3.Header.Hash, block2.Header.Hash, block.Header.Hash))

--- a/testapp/helpers.go
+++ b/testapp/helpers.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"cosmossdk.io/math"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -13,6 +14,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/polymerdao/monomer/testapp/x/testmodule"
 	"github.com/polymerdao/monomer/testapp/x/testmodule/types"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +59,16 @@ func ToTestTx(t *testing.T, k, v string) []byte {
 		FromAddress: "cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh",
 		Key:         k,
 		Value:       v,
+	})
+}
+
+func ToWithdrawalTx(t *testing.T, cosmosAddr string, ethAddr string, amount math.Int) []byte {
+	return toTx(t, &rolluptypes.MsgInitiateWithdrawal{
+		Sender:   cosmosAddr,
+		Target:   ethAddr,
+		Value:    amount,
+		GasLimit: []byte{0xff, 0xff, 0xff, 0xff, 0xff},
+		Data:     []byte{},
 	})
 }
 

--- a/testapp/helpers.go
+++ b/testapp/helpers.go
@@ -10,6 +10,7 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/polymerdao/monomer/testapp/x/testmodule"
 	"github.com/polymerdao/monomer/testapp/x/testmodule/types"
 	"github.com/stretchr/testify/require"
@@ -48,8 +49,8 @@ func MakeGenesisAppState(t *testing.T, app *App, kvs ...string) map[string]json.
 	return defaultGenesis
 }
 
-func ToTx(t *testing.T, k, v string) []byte {
-	msgAny, err := codectypes.NewAnyWithValue(&types.MsgSetValue{
+func ToTestTx(t *testing.T, k, v string) []byte {
+	return toTx(t, &types.MsgSetValue{
 		// TODO use real addresses and enable the signature and gas checks.
 		// This is just a dummy address. The signature and gas checks are disabled in testapp.go,
 		// so this works for now.
@@ -57,7 +58,12 @@ func ToTx(t *testing.T, k, v string) []byte {
 		Key:         k,
 		Value:       v,
 	})
+}
+
+func toTx(t *testing.T, msg proto.Message) []byte {
+	msgAny, err := codectypes.NewAnyWithValue(msg)
 	require.NoError(t, err)
+
 	tx := &sdktx.Tx{
 		Body: &sdktx.TxBody{
 			Messages: []*codectypes.Any{msgAny},
@@ -66,8 +72,8 @@ func ToTx(t *testing.T, k, v string) []byte {
 			Fee: &sdktx.Fee{},
 		},
 	}
-	txBytes := make([]byte, tx.Size())
-	_, err = tx.MarshalTo(txBytes)
+
+	txBytes, err := tx.Marshal()
 	require.NoError(t, err)
 	return txBytes
 }
@@ -77,7 +83,7 @@ func ToTx(t *testing.T, k, v string) []byte {
 func ToTxs(t *testing.T, kvs map[string]string) [][]byte {
 	var txs [][]byte
 	for k, v := range kvs {
-		txs = append(txs, ToTx(t, k, v))
+		txs = append(txs, ToTestTx(t, k, v))
 	}
 	// Ensure txs are always returned in the same order.
 	slices.SortFunc(txs, func(x []byte, y []byte) int {

--- a/testapp/testapp_test.go
+++ b/testapp/testapp_test.go
@@ -1,8 +1,8 @@
 package testapp_test
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -68,7 +68,7 @@ func build(t *testing.T, app *testapp.App, chainID string, height int64) (string
 	key := fmt.Sprintf("k%d", height)
 	value := fmt.Sprintf("v%d", height)
 	_, err := app.FinalizeBlock(context.Background(), &abcitypes.RequestFinalizeBlock{
-		Txs:    [][]byte{testapp.ToTx(t, key, value)},
+		Txs:    [][]byte{testapp.ToTestTx(t, key, value)},
 		Height: height,
 	})
 	require.NoError(t, err)

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -10,6 +10,8 @@ import (
 	cometdb "github.com/cometbft/cometbft-db"
 	bfttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -100,7 +102,7 @@ func cosmosTxsFromEthTxs(t *testing.T, l1InfoTx *gethtypes.Transaction, depositT
 		require.NoError(t, err)
 		ethTxBytes = append(ethTxBytes, cosmosEthTxBytes)
 	}
-	cosmosTxs, err := monomer.AdaptPayloadTxsToCosmosTxs(ethTxBytes, nil, "")
+	cosmosTxs, err := monomer.AdaptPayloadTxsToCosmosTxs(ethTxBytes, generateSignTx, sdk.AccAddress("addr").String())
 	require.NoError(t, err)
 	return cosmosTxs
 }
@@ -139,4 +141,11 @@ func GenerateL1Block() *gethtypes.Block {
 		Number:     big.NewInt(0),
 		Time:       uint64(0),
 	}, nil, nil, nil, trie.NewStackTrie(nil))
+}
+
+func generateSignTx(tx *sdktx.Tx) error {
+	tx.AuthInfo = &sdktx.AuthInfo{
+		Fee: &sdktx.Fee{},
+	}
+	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -20,4 +22,9 @@ func WrapCloseErr(err error, closer io.Closer) error {
 		return multierror.Append(err, closeErr)
 	}
 	return nil
+}
+
+// EvmToCosmosAddress converts an EVM address to a sdktypes.AccAddress
+func EvmToCosmosAddress(addr common.Address) sdktypes.AccAddress {
+	return addr.Bytes()
 }

--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -8,9 +8,9 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/polymerdao/monomer/utils"
 	"github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/samber/lo"
 )
@@ -91,7 +91,7 @@ func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) (sdk.Eve
 			ctx.Logger().Error("Contract creation txs are not supported", "index", i)
 			return nil, types.WrapError(types.ErrInvalidL1Txs, "Contract creation txs are not supported, index:%d", i)
 		}
-		cosmAddr := evmToCosmos(*to)
+		cosmAddr := utils.EvmToCosmosAddress(*to)
 		mintAmount := sdkmath.NewIntFromBigInt(tx.Value())
 		mintEvent, err := k.mintETH(ctx, cosmAddr, mintAmount)
 		if err != nil {
@@ -122,9 +122,4 @@ func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.In
 	)
 
 	return &mintEvent, nil
-}
-
-// evmToCosmos converts an EVM address to a sdk.AccAddress
-func evmToCosmos(addr common.Address) sdk.AccAddress {
-	return addr.Bytes()
 }


### PR DESCRIPTION
This PR introduces tests for withdrawal functionality and includes some refactoring changes to improve code structure and testability.

Key changes:

1. Withdrawal Tests:
	- Added tests for withdrawal messages in `builder_test.go`
	- Implemented ToWithdrawalTx testapp helper function for creating withdrawal transactions in tests
	- Added test for parseWithdrawalMessages to verify correct parsing of withdrawal messages
	- Added test for verifying received L1 deposit transactions before withdrawal

2. Refactoring:
	- Introduced EvmToCosmos function in adapters.go for centralized EVM to Cosmos address conversion

Fixes #139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a function to convert Ethereum addresses to Cosmos SDK account addresses, enhancing interoperability between the two platforms.
	- Introduced a utility for improved mock account retrieval functionality, allowing for more realistic testing scenarios.
	- Created a new function for initiating withdrawal transactions, expanding transaction capabilities.
	- Enhanced testing framework for withdrawal and deposit transactions, ensuring correctness throughout the transaction lifecycle.
	- Established a consistent Node.js version for the project to reduce compatibility issues.
	- Improved routing structure in documentation for better navigation.
	- Introduced a `BankKeeper` interface for consistent coin management operations within the rollup module.

- **Bug Fixes**
	- Improved error handling in account retrieval processes, enhancing mock behavior.

- **Tests**
	- Enhanced test coverage for withdrawal messages to ensure proper transaction handling and state validation.
	- Updated testing utilities for transaction creation, improving accuracy and clarity in test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->