### PR TITLE
Emit single `message` event when processing deposits

### DIFF
--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -63,8 +63,8 @@ func (k *Keeper) processL1AttributesTx(ctx sdk.Context, txBytes []byte) (*derive
 }
 
 // processL1UserDepositTxs processes the L1 user deposit txs, mints ETH to the user's cosmos address,
-// and emits the minted ETH events.
-func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) error { //nolint:gocritic // hugeParam
+// and returns associated events.
+func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) (sdk.Events, error) { //nolint:gocritic // hugeParam
 	events := sdk.Events{}
 
 	for i := 1; i < len(txs); i++ {
@@ -72,15 +72,15 @@ func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) error { 
 		var tx ethtypes.Transaction
 		if err := tx.UnmarshalBinary(txBytes); err != nil {
 			ctx.Logger().Error("Failed to unmarshal user deposit transaction", "index", i, "err", err, "txBytes", txBytes)
-			return types.WrapError(types.ErrInvalidL1Txs, "failed to unmarshal user deposit transaction", "index", i, "err", err)
+			return nil, types.WrapError(types.ErrInvalidL1Txs, "failed to unmarshal user deposit transaction", "index", i, "err", err)
 		}
 		if !tx.IsDepositTx() {
 			ctx.Logger().Error("L1 tx must be a user deposit tx", "index", i, "type", tx.Type())
-			return types.WrapError(types.ErrInvalidL1Txs, "L1 tx must be a user deposit tx, index:%d, type:%d", i, tx.Type())
+			return nil, types.WrapError(types.ErrInvalidL1Txs, "L1 tx must be a user deposit tx, index:%d, type:%d", i, tx.Type())
 		}
 		if tx.IsSystemTx() {
 			ctx.Logger().Error("L1 tx must be a user deposit tx", "type", tx.Type())
-			return types.WrapError(types.ErrInvalidL1Txs, "L1 tx must be a user deposit tx, type %d", tx.Type())
+			return nil, types.WrapError(types.ErrInvalidL1Txs, "L1 tx must be a user deposit tx, type %d", tx.Type())
 		}
 		ctx.Logger().Debug("User deposit tx", "index", i, "tx", string(lo.Must(tx.MarshalJSON())))
 		to := tx.To()
@@ -88,20 +88,19 @@ func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) error { 
 		// see https://github.com/ethereum-optimism/op-geth/blob/v1.101301.0-rc.2/core/state_processor.go#L154
 		if to == nil {
 			ctx.Logger().Error("Contract creation txs are not supported", "index", i)
-			return types.WrapError(types.ErrInvalidL1Txs, "Contract creation txs are not supported, index:%d", i)
+			return nil, types.WrapError(types.ErrInvalidL1Txs, "Contract creation txs are not supported, index:%d", i)
 		}
 		cosmAddr := evmToCosmos(*to)
 		mintAmount := sdkmath.NewIntFromBigInt(tx.Value())
 		txEvents, err := k.mintETH(ctx, cosmAddr, mintAmount)
 		if err != nil {
 			ctx.Logger().Error("Failed to mint ETH", "evmAddress", to, "cosmosAddress", cosmAddr, "err", err)
-			return types.WrapError(types.ErrMintETH, "failed to mint ETH for cosmosAddress: %v; err: %v", cosmAddr, err)
+			return nil, types.WrapError(types.ErrMintETH, "failed to mint ETH for cosmosAddress: %v; err: %v", cosmAddr, err)
 		}
 		events = append(events, txEvents...)
 	}
 
-	ctx.EventManager().EmitEvents(events)
-	return nil
+	return events, nil
 }
 
 // mintETH mints ETH to an account where the amount is in wei. It returns associated events.

--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -67,6 +67,7 @@ func (k *Keeper) processL1AttributesTx(ctx sdk.Context, txBytes []byte) (*derive
 func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) (sdk.Events, error) { //nolint:gocritic // hugeParam
 	events := sdk.Events{}
 
+	// skip the first tx - it is the L1 attributes tx
 	for i := 1; i < len(txs); i++ {
 		txBytes := txs[i]
 		var tx ethtypes.Transaction

--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -62,8 +62,11 @@ func (k *Keeper) processL1AttributesTx(ctx sdk.Context, txBytes []byte) (*derive
 	return l1blockInfo, nil
 }
 
-// processL1UserDepositTxs processes the L1 user deposit txs and mints ETH to the user's cosmos address.
+// processL1UserDepositTxs processes the L1 user deposit txs, mints ETH to the user's cosmos address,
+// and emits the minted ETH events.
 func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) error { //nolint:gocritic // hugeParam
+	events := sdk.Events{}
+
 	for i := 1; i < len(txs); i++ {
 		txBytes := txs[i]
 		var tx ethtypes.Transaction
@@ -89,27 +92,29 @@ func (k *Keeper) processL1UserDepositTxs(ctx sdk.Context, txs [][]byte) error { 
 		}
 		cosmAddr := evmToCosmos(*to)
 		mintAmount := sdkmath.NewIntFromBigInt(tx.Value())
-		err := k.mintETH(ctx, cosmAddr, mintAmount)
+		txEvents, err := k.mintETH(ctx, cosmAddr, mintAmount)
 		if err != nil {
 			ctx.Logger().Error("Failed to mint ETH", "evmAddress", to, "cosmosAddress", cosmAddr, "err", err)
 			return types.WrapError(types.ErrMintETH, "failed to mint ETH for cosmosAddress: %v; err: %v", cosmAddr, err)
 		}
+		events = append(events, txEvents...)
 	}
+
+	ctx.EventManager().EmitEvents(events)
 	return nil
 }
 
-// mintETH mints ETH to an account where the amount is in wei.
-func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.Int) error { //nolint:gocritic // hugeParam
+// mintETH mints ETH to an account where the amount is in wei. It returns associated events.
+func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.Int) (sdk.Events, error) { //nolint:gocritic // hugeParam
 	coin := sdk.NewCoin(types.ETH, amount)
 	if err := k.bankkeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(coin)); err != nil {
-		return fmt.Errorf("failed to mint deposit coins to the rollup module: %v", err)
+		return nil, fmt.Errorf("failed to mint deposit coins to the rollup module: %v", err)
 	}
 	if err := k.bankkeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, sdk.NewCoins(coin)); err != nil {
-		return fmt.Errorf("failed to send deposit coins from rollup module to user account %v: %v", addr, err)
+		return nil, fmt.Errorf("failed to send deposit coins from rollup module to user account %v: %v", addr, err)
 	}
 
-	// TODO: only emit sdk.EventTypeMessage once per message
-	ctx.EventManager().EmitEvents(sdk.Events{
+	return sdk.Events{
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
@@ -120,8 +125,7 @@ func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.In
 			sdk.NewAttribute(types.AttributeKeyToCosmosAddress, addr.String()),
 			sdk.NewAttribute(types.AttributeKeyValue, hexutil.Encode(amount.BigInt().Bytes())),
 		),
-	})
-	return nil
+	}, nil
 }
 
 // evmToCosmos converts an EVM address to a sdk.AccAddress

--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -116,10 +116,6 @@ func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.In
 
 	return sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-		),
-		sdk.NewEvent(
 			types.EventTypeMintETH,
 			sdk.NewAttribute(types.AttributeKeyL1DepositTxType, types.L1UserDepositTxType),
 			sdk.NewAttribute(types.AttributeKeyToCosmosAddress, addr.String()),

--- a/x/rollup/keeper/keeper.go
+++ b/x/rollup/keeper/keeper.go
@@ -1,8 +1,11 @@
 package keeper
 
 import (
+	"context"
+
 	"cosmossdk.io/core/store"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/polymerdao/monomer/x/rollup/types"
 )
@@ -26,4 +29,18 @@ func NewKeeper(
 		bankkeeper:   bankKeeper,
 		rollupCfg:    &rollup.Config{},
 	}
+}
+
+// Helper. Prepares a `message` event with the module name and emits it
+// along with the provided events.
+func (k *Keeper) EmitEvents(goCtx context.Context, events sdk.Events) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	moduleEvent := sdk.NewEvent(
+		sdk.EventTypeMessage,
+		sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
+	)
+	events = append(sdk.Events{moduleEvent}, events...)
+
+	ctx.EventManager().EmitEvents(events)
 }

--- a/x/rollup/keeper/keeper_test.go
+++ b/x/rollup/keeper/keeper_test.go
@@ -22,6 +22,7 @@ type KeeperTestSuite struct {
 	rollupKeeper *keeper.Keeper
 	bankKeeper   *rolluptestutil.MockBankKeeper
 	rollupStore  storetypes.KVStore
+	eventManger  sdk.EventManagerI
 }
 
 func TestKeeperTestSuite(t *testing.T) {
@@ -40,7 +41,9 @@ func (s *KeeperTestSuite) SetupSubTest() {
 		runtime.NewKVStoreService(storeKey),
 		s.bankKeeper,
 	)
-	s.rollupStore = sdk.UnwrapSDKContext(s.ctx).KVStore(storeKey)
+	sdkCtx := sdk.UnwrapSDKContext(s.ctx)
+	s.rollupStore = sdkCtx.KVStore(storeKey)
+	s.eventManger = sdkCtx.EventManager()
 }
 
 func (s *KeeperTestSuite) mockBurnETH() {

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -52,14 +52,22 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 	ctx.Logger().Info("Save L1 block history info", "l1blockHistoryInfo", string(lo.Must(json.Marshal(l1blockInfo))))
 
 	// process L1 user deposit txs
-	events, err := k.processL1UserDepositTxs(ctx, msg.TxBytes)
+	mintEvents, err := k.processL1UserDepositTxs(ctx, msg.TxBytes)
 
 	if err != nil {
 		ctx.Logger().Error("Failed to process L1 user deposit txs", "err", err)
 		return nil, types.WrapError(types.ErrProcessL1UserDepositTxs, "err: %v", err)
 	}
 
-	ctx.EventManager().EmitEvents(events)
+	ctx.EventManager().EmitEvents(
+		append(
+			sdk.Events{
+				sdk.NewEvent(
+					sdk.EventTypeMessage,
+					sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
+				)},
+			mintEvents...),
+	)
 
 	return &types.MsgApplyL1TxsResponse{}, nil
 }

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -58,16 +58,7 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 		return nil, types.WrapError(types.ErrProcessL1UserDepositTxs, "err: %v", err)
 	}
 
-	ctx.EventManager().EmitEvents(
-		append(
-			sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-				),
-			},
-			mintEvents...),
-	)
+	k.EmitEvents(goCtx, mintEvents)
 
 	return &types.MsgApplyL1TxsResponse{}, nil
 }
@@ -91,11 +82,7 @@ func (k *Keeper) InitiateWithdrawal(
 	}
 
 	withdrawalValueHex := hexutil.Encode(msg.Value.BigInt().Bytes())
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-		),
+	k.EmitEvents(ctx, sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeWithdrawalInitiated,
 			sdk.NewAttribute(types.AttributeKeySender, msg.Sender),

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -53,7 +53,6 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 
 	// process L1 user deposit txs
 	mintEvents, err := k.processL1UserDepositTxs(ctx, msg.TxBytes)
-
 	if err != nil {
 		ctx.Logger().Error("Failed to process L1 user deposit txs", "err", err)
 		return nil, types.WrapError(types.ErrProcessL1UserDepositTxs, "err: %v", err)
@@ -65,7 +64,8 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 				sdk.NewEvent(
 					sdk.EventTypeMessage,
 					sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-				)},
+				),
+			},
 			mintEvents...),
 	)
 

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -52,10 +52,14 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 	ctx.Logger().Info("Save L1 block history info", "l1blockHistoryInfo", string(lo.Must(json.Marshal(l1blockInfo))))
 
 	// process L1 user deposit txs
-	if err = k.processL1UserDepositTxs(ctx, msg.TxBytes); err != nil {
+	events, err := k.processL1UserDepositTxs(ctx, msg.TxBytes)
+
+	if err != nil {
 		ctx.Logger().Error("Failed to process L1 user deposit txs", "err", err)
 		return nil, types.WrapError(types.ErrProcessL1UserDepositTxs, "err: %v", err)
 	}
+
+	ctx.EventManager().EmitEvents(events)
 
 	return &types.MsgApplyL1TxsResponse{}, nil
 }

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -35,10 +35,20 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 		"successful message with single user deposit tx": {
 			txBytes:     [][]byte{l1AttributesTxBz, depositTxBz},
 			shouldError: false,
+			expectedEventTypes: []string{
+				sdk.EventTypeMessage,
+				types.EventTypeMintETH,
+			},
 		},
 		"successful message with multiple user deposit txs": {
 			txBytes:     [][]byte{l1AttributesTxBz, depositTxBz, depositTxBz},
 			shouldError: false,
+			expectedEventTypes: []string{
+				sdk.EventTypeMessage,
+				types.EventTypeMintETH,
+				sdk.EventTypeMessage,
+				types.EventTypeMintETH,
+			},
 		},
 		"invalid l1 attributes tx bytes": {
 			txBytes:     [][]byte{invalidTxBz, depositTxBz},

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -32,6 +32,13 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 		shouldError        bool
 		expectedEventTypes []string
 	}{
+		"successful message with no user deposit txs": {
+			txBytes:     [][]byte{l1AttributesTxBz},
+			shouldError: false,
+			expectedEventTypes: []string{
+				sdk.EventTypeMessage,
+			},
+		},
 		"successful message with single user deposit tx": {
 			txBytes:     [][]byte{l1AttributesTxBz, depositTxBz},
 			shouldError: false,

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -27,9 +27,10 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 	invalidTxBz := []byte("invalid tx bytes")
 
 	tests := map[string]struct {
-		txBytes     [][]byte
-		setupMocks  func()
-		shouldError bool
+		txBytes            [][]byte
+		setupMocks         func()
+		shouldError        bool
+		expectedEventTypes []string
 	}{
 		"successful message with single user deposit tx": {
 			txBytes:     [][]byte{l1AttributesTxBz, depositTxBz},
@@ -105,7 +106,10 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 				s.Require().NoError(err)
 				s.Require().NotNil(resp)
 
-				// TODO: Verify that the expected event types are emitted
+				// Verify that the expected event types are emitted
+				for i, event := range s.eventManger.Events() {
+					s.Require().Equal(test.expectedEventTypes[i], event.Type)
+				}
 
 				// Verify that the l1 block info and l1 block history are saved to the store
 				expectedBlockInfo := eth.BlockToInfo(testutils.GenerateL1Block())

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -53,7 +53,6 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 			expectedEventTypes: []string{
 				sdk.EventTypeMessage,
 				types.EventTypeMintETH,
-				sdk.EventTypeMessage,
 				types.EventTypeMintETH,
 			},
 		},

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -207,7 +207,7 @@ func (s *KeeperTestSuite) TestInitiateWithdrawal() {
 					types.EventTypeWithdrawalInitiated,
 					types.EventTypeBurnETH,
 				}
-				for i, event := range sdk.UnwrapSDKContext(s.ctx).EventManager().Events() {
+				for i, event := range s.eventManger.Events() {
 					s.Require().Equal(expectedEventTypes[i], event.Type)
 				}
 			}


### PR DESCRIPTION
PR closes #162.

PR 
- alters `deposits.go/processL1UserDepositTxs` to gather and _return_ (instead of emitting) mint events _only_
- alters `msg_server.go/ApplyL1Txs` to craft the `sdk.EventTypeMessage` message, and emit along with the gathered mint events
- adds a test assertion that the correct events are emitted on well-formed collections of deposit TXs
  - adds the EventManager as part of the constructed test suite for visibility
  - adds a success test case with no user deposit TXs (`[0, 1, some]` seems more complete than `[1, some]`)

  
Drive-by question: why is it that we want to emit the `sdk.EventTypeMessage` message? Maybe a cosmos convention that modules prepend their emissions with a module-scope?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced user deposit transaction processing with improved event handling and error reporting.
  - Streamlined feedback on ETH minting events, providing users with clearer insights into transaction outcomes.
  - Introduced a new function for emitting structured events related to transactions, improving event tracking.

- **Bug Fixes**
  - Improved error handling in transaction processing to ensure events are only emitted on successful transactions.

- **Tests**
  - Updated test cases to verify expected event types during transaction processing, enhancing the reliability of the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->