### PR TITLE
[Optional] Add an EmitEvents helper to de-duplicate message event construction

### DIFF
--- a/x/rollup/keeper/keeper.go
+++ b/x/rollup/keeper/keeper.go
@@ -1,8 +1,11 @@
 package keeper
 
 import (
+	"context"
+
 	"cosmossdk.io/core/store"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/polymerdao/monomer/x/rollup/types"
 )
@@ -26,4 +29,18 @@ func NewKeeper(
 		bankkeeper:   bankKeeper,
 		rollupCfg:    &rollup.Config{},
 	}
+}
+
+// Helper. Prepares a `message` event with the module name and emits it
+// along with the provided events.
+func (k *Keeper) EmitEvents(goCtx context.Context, events sdk.Events) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	moduleEvent := sdk.NewEvent(
+		sdk.EventTypeMessage,
+		sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
+	)
+	events = append(sdk.Events{moduleEvent}, events...)
+
+	ctx.EventManager().EmitEvents(events)
 }

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -58,16 +58,7 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 		return nil, types.WrapError(types.ErrProcessL1UserDepositTxs, "err: %v", err)
 	}
 
-	ctx.EventManager().EmitEvents(
-		append(
-			sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-				),
-			},
-			mintEvents...),
-	)
+	k.EmitEvents(goCtx, mintEvents)
 
 	return &types.MsgApplyL1TxsResponse{}, nil
 }
@@ -91,11 +82,7 @@ func (k *Keeper) InitiateWithdrawal(
 	}
 
 	withdrawalValueHex := hexutil.Encode(msg.Value.BigInt().Bytes())
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-		),
+	k.EmitEvents(ctx, sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeWithdrawalInitiated,
 			sdk.NewAttribute(types.AttributeKeySender, msg.Sender),


### PR DESCRIPTION
Currently, `msg_server.go` emits events in two locations. In each location, it constructs a `message` event with its module name attached:

```go
sdk.NewEvent(
	sdk.EventTypeMessage,
	sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
)
```

This is somewhat error-prone - could forget to prepend these messages on other event emissions.

This PR adds a helper to the `keeper` struct to encapsulate this `message` event prepend operation.