### PR TITLE
[debug] Add timestamped prints to illustrate rollback

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -221,7 +221,7 @@ func (b *Builder) Build(ctx context.Context, payload *Payload) (*monomer.Block, 
 		}
 	}
 
-	ts(fmt.Sprintf("Block built: %d", block.Header.Height))
+	ts(fmt.Sprintf("Block built: %d, %s", block.Header.Height, block.Header.Hash.String()))
 
 	// TODO publish other things like new blocks.
 	return block, nil

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+	"time"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	bfttypes "github.com/cometbft/cometbft/types"
@@ -66,6 +67,8 @@ func New(
 //   - all hashes exist in the block store.
 //   - finalized.Height <= safe.Height <= head.Height
 func (b *Builder) Rollback(ctx context.Context, unsafe, safe, finalized common.Hash) error {
+	ts(fmt.Sprintf("Rolling back from %s to %s, with finalized %s\n", unsafe.String(), safe.String(), finalized.String()))
+
 	currentHeight, err := b.blockStore.Height()
 	if err != nil {
 		return fmt.Errorf("get height: %v", err)
@@ -218,6 +221,8 @@ func (b *Builder) Build(ctx context.Context, payload *Payload) (*monomer.Block, 
 		}
 	}
 
+	ts(fmt.Sprintf("Block built: %d", block.Header.Height))
+
 	// TODO publish other things like new blocks.
 	return block, nil
 }
@@ -316,4 +321,14 @@ func (b *Builder) storeWithdrawalMsgInEVM(
 	}
 
 	return messageNonce, nil
+}
+
+var start time.Time
+
+func ts(s string) {
+	if start == (time.Time{}) {
+		start = time.Now()
+	}
+
+	fmt.Printf("[%d] %s\n", time.Since(start).Milliseconds(), s)
 }

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
@@ -104,6 +105,8 @@ func TestE2E(t *testing.T) {
 	// Run tests concurrently, against the same stack.
 	runningTests := sync.WaitGroup{}
 	runningTests.Add(len(e2eTests))
+
+	time.Sleep(15 * time.Second) // watching for rollbacks
 
 	for _, test := range e2eTests {
 		t.Run(test.name, func(t *testing.T) {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -91,6 +91,8 @@ func (g *Genesis) Commit(ctx context.Context, app monomer.Application, blockStor
 		return fmt.Errorf("make block: %v", err)
 	}
 
+	fmt.Println("Genesis block hash:", block.Header.Hash.String())
+
 	if err := blockStore.AppendBlock(block); err != nil {
 		return fmt.Errorf("append block: %v", err)
 	}


### PR DESCRIPTION
@natebeauregard 

This branch is a minimal diff from `main` that might provide some small clarity on the e2e rollbacks. Created as a PR just for notification purpose - feel free to close it.

The test here produces output like this:

```
[0] Block built: 2
[3] Block built: 3
[388] Block built: 4
[1385] Block built: 5
[2386] Block built: 6
[3386] Block built: 7
[4388] Block built: 8
[5385] Block built: 9
[6386] Block built: 10
[7387] Block built: 11
[8387] Block built: 12
[9386] Block built: 13
[10009] Rolling back from 0x3063a0dbd366ac2b4580940e13e40dfd9a276ba3f6385325edd3ad105b6e3590 to 0x3063a0dbd366ac2b4580940e13e40dfd9a276ba3f6385325edd3ad105b6e3590, with finalized 0x6b6a4df1a526c33818490656d0c064e295f3850bb0aa33f3bc6b830c22f173b3

[10012] Block built: 5
[10016] Block built: 6
[10026] Block built: 7
[10031] Block built: 8
[10037] Block built: 9
[10045] Block built: 10
[10052] Block built: 11
[10058] Block built: 12
[10062] Block built: 13
[10386] Block built: 14
[11386] Block built: 15
[12387] Block built: 16
```

The timestamps are in milliseconds, 0-indexed from the first block produced.

Potential notables:
- the sleep here is before the tests are run. The rollback **is not triggered** by any "external inputs" to the stack
- after the rollback occurs, monomer more or less instantly reproduces blocks up to the height at which the rollback occurred
- the rollback **is** initiated by a call to `builder.Rollback`

---

If we also modify the deposit test with `err = stack.WaitL1(2)` instead of its existing wait, the tests all pass:

```
=== RUN   TestE2E
[0] Block built: 2
[7] Block built: 3
[160] Block built: 4
[1161] Block built: 5
[2160] Block built: 6
[3160] Block built: 7
[4162] Block built: 8
[5160] Block built: 9
[6160] Block built: 10
[7161] Block built: 11
[8162] Block built: 12
[9160] Block built: 13
[10007] Rolling back from 0x51083af201ddd13b66054105a275d642fa783ce7b98cbe7d816ddffbdba1d270 to 0x51083af201ddd13b66054105a275d642fa783ce7b98cbe7d816ddffbdba1d270, with finalized 0x7db8ac402fa619536f61253066041c4672af67dcc4597648eb5609a5509969d7

[10010] Block built: 5
[10016] Block built: 6
[10023] Block built: 7
[10031] Block built: 8
[10040] Block built: 9
[10051] Block built: 10
[10064] Block built: 11
[10073] Block built: 12
[10083] Block built: 13
[10160] Block built: 14
[11160] Block built: 15
[12161] Block built: 16
=== RUN   TestE2E/L1_Deposits
=== RUN   TestE2E/CometBFT_Txs
=== RUN   TestE2E/AttributesTX
[13167] Block built: 17
[14161] Block built: 18
[15170] Block built: 19
[16161] Block built: 20
[17159] Block built: 21
--- PASS: TestE2E (19.40s)
    --- PASS: TestE2E/L1_Deposits (0.00s)
    --- PASS: TestE2E/CometBFT_Txs (0.00s)
    --- PASS: TestE2E/AttributesTX (0.00s)
    stack_test.go:152: Monomer can ingest cometbft txs
    stack_test.go:158: Monomer can reject malformed cometbft txs
    stack_test.go:169: Monomer can serve txs by hash
    stack_test.go:278: Monomer can mint_eth from L1 user deposits
    stack_test.go:141: Monomer blocks contain the l1 attributes deposit tx
PASS
ok      github.com/polymerdao/monomer/e2e       19.511s
```

---

If we sleep for 60 seconds, we see a regular pattern of rollbacks every 10 blocks starting at 13 (apologies for big dump)


```log
go test -v ./e2e
=== RUN   TestE2E
[0] Block built: 2
[6] Block built: 3
[713] Block built: 4
[1713] Block built: 5
[2715] Block built: 6
[3713] Block built: 7
[4714] Block built: 8
[5713] Block built: 9
[6714] Block built: 10
[7713] Block built: 11
[8713] Block built: 12
[9714] Block built: 13
[9992] Rolling back from 0x3141eb4f84bf5cdd7e84624f546d5f8112023e2ff2e4032992cb20d7c75717d0 to 0x3141eb4f84bf5cdd7e84624f546d5f8112023e2ff2e4032992cb20d7c75717d0, with finalized 0x451fc2fae004dd8eca00b75ab6ba0951f8279e7b0205cb0e51e4a2e9479a48f0

[9994] Block built: 5
[9998] Block built: 6
[10001] Block built: 7
[10004] Block built: 8
[10006] Block built: 9
[10009] Block built: 10
[10011] Block built: 11
[10015] Block built: 12
[10018] Block built: 13
[10712] Block built: 14
[11713] Block built: 15
[12714] Block built: 16
[13713] Block built: 17
[14714] Block built: 18
[15713] Block built: 19
[16713] Block built: 20
[17713] Block built: 21
[18712] Block built: 22
[19712] Block built: 23
[19994] Rolling back from 0xe5bb7ed33ec9d0a7e96d8e7ec374a612cafe6892cc7d84071c0f414fe83aa7a1 to 0xe5bb7ed33ec9d0a7e96d8e7ec374a612cafe6892cc7d84071c0f414fe83aa7a1, with finalized 0x451fc2fae004dd8eca00b75ab6ba0951f8279e7b0205cb0e51e4a2e9479a48f0

[19997] Block built: 15
[20000] Block built: 16
[20003] Block built: 17
[20006] Block built: 18
[20008] Block built: 19
[20011] Block built: 20
[20014] Block built: 21
[20016] Block built: 22
[20019] Block built: 23
[20715] Block built: 24
[21716] Block built: 25
[22714] Block built: 26
[23714] Block built: 27
[24712] Block built: 28
[25714] Block built: 29
[26713] Block built: 30
[27713] Block built: 31
[28714] Block built: 32
[29714] Block built: 33
[30005] Rolling back from 0xfb4f6d1cadf94a3fbdbc3087040f73ecbcc7723793826512c97620e80a9e714f to 0xfb4f6d1cadf94a3fbdbc3087040f73ecbcc7723793826512c97620e80a9e714f, with finalized 0x451fc2fae004dd8eca00b75ab6ba0951f8279e7b0205cb0e51e4a2e9479a48f0

[30012] Block built: 25
[30024] Block built: 26
[30036] Block built: 27
[30039] Block built: 28
[30042] Block built: 29
[30046] Block built: 30
[30049] Block built: 31
[30052] Block built: 32
[30055] Block built: 33
[30715] Block built: 34
[31715] Block built: 35
[32712] Block built: 36
[33714] Block built: 37
[34714] Block built: 38
[35715] Block built: 39
[36714] Block built: 40
[37715] Block built: 41
[38714] Block built: 42
[39715] Block built: 43
[40005] Rolling back from 0x8f22936e69ad4d8203f349aa0fbcc226961ff0e9ac8a8a64d805d8dde632b956 to 0x8f22936e69ad4d8203f349aa0fbcc226961ff0e9ac8a8a64d805d8dde632b956, with finalized 0x451fc2fae004dd8eca00b75ab6ba0951f8279e7b0205cb0e51e4a2e9479a48f0

[40013] Block built: 35
[40023] Block built: 36
[40039] Block built: 37
[40049] Block built: 38
[40053] Block built: 39
[40055] Block built: 40
[40058] Block built: 41
[40062] Block built: 42
[40064] Block built: 43
[40713] Block built: 44
[41714] Block built: 45
[42713] Block built: 46
[43713] Block built: 47
[44715] Block built: 48
[45714] Block built: 49
[46714] Block built: 50
[47714] Block built: 51
[48714] Block built: 52
[49713] Block built: 53
[49999] Rolling back from 0x7e2687259a819208c08c0720bd76d9afb03c9cc5d0cf1a85d974d5ff01b49a49 to 0x7e2687259a819208c08c0720bd76d9afb03c9cc5d0cf1a85d974d5ff01b49a49, with finalized 0x451fc2fae004dd8eca00b75ab6ba0951f8279e7b0205cb0e51e4a2e9479a48f0

[50002] Block built: 45
[50012] Block built: 46
[50022] Block built: 47
[50037] Block built: 48
[50044] Block built: 49
[50050] Block built: 50
[50064] Block built: 51
[50076] Block built: 52
[50087] Block built: 53
[50716] Block built: 54
[51714] Block built: 55
[52712] Block built: 56
[53715] Block built: 57
[54712] Block built: 58
[55714] Block built: 59
[56715] Block built: 60
[57713] Block built: 61
--- PASS: TestE2E (60.07s)
PASS
ok  	github.com/polymerdao/monomer/e2e	60.156s
```