### PR TITLE
[DOC] Add more replace directives...

### DIFF
--- a/doc/docs/learn/create-an-app-with-monomer.md
+++ b/doc/docs/learn/create-an-app-with-monomer.md
@@ -184,8 +184,9 @@ func initRootCmd(
 ```
 
 ## Building the Application
-Before we can build our application, we need to add the following replace directives in `go.mod` and then run `go mod
-tidy`: 
+To resolve some breaking changes in minor versions, we need the following replace directives. Add them to `go.mod`, then run `go mod
+tidy`.
+
 ```go
 github.com/ethereum/go-ethereum => github.com/joshklop/op-geth v0.0.0-20240515205036-e3b990384a74
 github.com/libp2p/go-libp2p => github.com/joshklop/go-libp2p v0.0.0-20240814165419-c6b91fa9f263

--- a/doc/docs/learn/create-an-app-with-monomer.md
+++ b/doc/docs/learn/create-an-app-with-monomer.md
@@ -189,6 +189,9 @@ tidy`:
 ```go
 github.com/ethereum/go-ethereum => github.com/joshklop/op-geth v0.0.0-20240515205036-e3b990384a74
 github.com/libp2p/go-libp2p => github.com/joshklop/go-libp2p v0.0.0-20240814165419-c6b91fa9f263
+github.com/btcsuite/btcd/btcec/v2 v2.3.4 => github.com/btcsuite/btcd/btcec/v2 v2.3.2
+github.com/crate-crypto/go-kzg-4844 v1.0.0 => github.com/crate-crypto/go-kzg-4844 v0.7.0
+github.com/crate-crypto/go-ipa => github.com/crate-crypto/go-ipa v0.0.0-20231205143816-408dbffb2041
 ```
 
 and change the `cosmossdk.io/core` replace directive to `v0.11.1`:


### PR DESCRIPTION
Current instructions for modifying `spawn`'s default output as a rollup appchain were broken, due to some dependencies having made (API breaking) updates.

PR resolves this issue by adding extra `replace` directives on the problem dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated dependency versions to improve compatibility and functionality.
	- Introduced a new dependency to enhance project capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->