### PR TITLE
Refactor e2e tests: Replace static blob artifact dir with `os.TempDir()`

### DIFF
--- a/e2e/gethdevnet.go
+++ b/e2e/gethdevnet.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"fmt"
-	"path/filepath"
+	"os"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
@@ -14,7 +14,7 @@ import (
 )
 
 func gethdevnet(env *environment.Env, blockTime uint64, genesis *core.Genesis) (*rpc.Client, string, error) {
-	blobsDirectory := filepath.Join("artifacts", "blobs")
+	blobsDirectory := os.TempDir()
 
 	beacon := fakebeacon.NewBeacon(nil, blobsDirectory, genesis.Timestamp, blockTime)
 	myClock := clock.NewAdvancingClock(time.Second) // Arbitrary working duration. Eventually consumed by geth lifecycle instances.


### PR DESCRIPTION
Fixes #173

This PR addresses the issue of an unused `blobs_bundle_1.json` artifact being generated during e2e tests. Since Monomer is not currently using blobs, this file is unnecessary.

Changes:
- Refactored `gethdevnet.go` to use `os.TempDir()` instead of a hardcoded artifacts directory for blobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated blob storage management to utilize the system's temporary directory, enhancing file management and cleanup processes during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->