### PR TITLE
Refactor: remove setL1BlockHistory function

### DIFF
--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -25,20 +24,7 @@ func (k *Keeper) setL1BlockInfo(ctx sdk.Context, info derive.L1BlockInfo) error 
 		return types.WrapError(err, "marshal L1 block info")
 	}
 	if err = k.storeService.OpenKVStore(ctx).Set([]byte(types.KeyL1BlockInfo), infoBytes); err != nil {
-		return types.WrapError(err, "set")
-	}
-	return nil
-}
-
-// TODO: include the logic to also store the L1 block info by blockhash in setL1BlockInfo and remove setL1BlockHistory
-// setL1BlockHistory sets the L1 block info to the app state, with the key being the blockhash, so we can look it up easily later.
-func (k *Keeper) setL1BlockHistory(ctx context.Context, info *derive.L1BlockInfo) error {
-	infoBytes, err := json.Marshal(info)
-	if err != nil {
-		return types.WrapError(err, "marshal L1 block info")
-	}
-	if err = k.storeService.OpenKVStore(ctx).Set(info.BlockHash.Bytes(), infoBytes); err != nil {
-		return types.WrapError(err, "set")
+		return types.WrapError(err, "set latest L1 block info")
 	}
 	return nil
 }

--- a/x/rollup/keeper/msg_server.go
+++ b/x/rollup/keeper/msg_server.go
@@ -33,14 +33,6 @@ func (k *Keeper) ApplyL1Txs(goCtx context.Context, msg *types.MsgApplyL1Txs) (*t
 
 	ctx.Logger().Info("Save L1 block info", "l1blockInfo", string(lo.Must(json.Marshal(l1blockInfo))))
 
-	// save L1 block History to AppState
-	if err = k.setL1BlockHistory(&ctx, l1blockInfo); err != nil {
-		ctx.Logger().Error("Failed to save L1 block history info to AppState", "err", err)
-		return nil, types.WrapError(types.ErrL1BlockInfo, "save error: %v", err)
-	}
-
-	ctx.Logger().Info("Save L1 block history info", "l1blockHistoryInfo", string(lo.Must(json.Marshal(l1blockInfo))))
-
 	// process L1 user deposit txs
 	mintEvents, err := k.processL1UserDepositTxs(ctx, msg.TxBytes)
 	if err != nil {

--- a/x/rollup/keeper/msg_server_test.go
+++ b/x/rollup/keeper/msg_server_test.go
@@ -129,10 +129,7 @@ func (s *KeeperTestSuite) TestApplyL1Txs() {
 				// Verify that the l1 block info and l1 block history are saved to the store
 				expectedBlockInfo := eth.BlockToInfo(testutils.GenerateL1Block())
 				l1BlockInfoBz := s.rollupStore.Get([]byte(types.KeyL1BlockInfo))
-				historicalL1BlockInfoBz := s.rollupStore.Get(expectedBlockInfo.Hash().Bytes())
 				s.Require().NotNil(l1BlockInfoBz)
-				s.Require().NotNil(historicalL1BlockInfoBz)
-				s.Require().Equal(l1BlockInfoBz, historicalL1BlockInfoBz)
 
 				var l1BlockInfo *derive.L1BlockInfo
 				err = json.Unmarshal(l1BlockInfoBz, &l1BlockInfo)


### PR DESCRIPTION
Fixes #163
Refactor: remove setL1BlockHistory function and no longer store historical block info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error handling with more descriptive messages for L1 block information management.
	- Streamlined logic for storing L1 block information, enhancing code readability.

- **Bug Fixes**
	- Removed redundant context parameter from block history method, simplifying its usage.

- **Chores**
	- Eliminated obsolete code related to saving L1 block history, optimizing application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->