### PR TITLE
Fix e2e test rollbacks

### DIFF
--- a/e2e/op_stack.go
+++ b/e2e/op_stack.go
@@ -228,10 +228,9 @@ func (op *OPStack) runBatcher(ctx context.Context, env *environment.Env, l1Clien
 		L1Client:         l1Client,
 		EndpointProvider: endpointProvider,
 		ChannelConfig: batcher.ChannelConfig{
-			SeqWindowSize:      op.rollupConfig.SeqWindowSize,
-			ChannelTimeout:     op.rollupConfig.ChannelTimeout,
-			MaxChannelDuration: 1,
-			SubSafetyMargin:    4,
+			SeqWindowSize:   op.rollupConfig.SeqWindowSize,
+			ChannelTimeout:  op.rollupConfig.ChannelTimeout,
+			SubSafetyMargin: op.rollupConfig.SeqWindowSize / 2,
 			// MaxFrameSize field value is copied from:
 			//nolint:lll
 			// https://github.com/ethereum-optimism/optimism/blob/5b13bad9883fa5737af67ba3ee700aaa8737f686/op-batcher/batcher/channel_config_test.go#L19

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -183,6 +183,8 @@ func (s *stack) run(ctx context.Context, env *environment.Env) (*StackConfig, er
 		})
 	}
 
+	deployConfig.BatchSenderAddress = l1users[0].Address
+
 	l1genesis, err := opgenesis.BuildL1DeveloperGenesis(deployConfig, l1state, l1Deployments)
 	if err != nil {
 		return nil, fmt.Errorf("build l1 developer genesis: %v", err)

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -131,13 +131,10 @@ func (s *stack) run(ctx context.Context, env *environment.Env) (*StackConfig, er
 	deployConfig.SetDeployments(l1Deployments)
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	deployConfig.L1UseClique = false // Allows node to produce blocks without addition config. Clique is a PoA config.
-	// SequencerWindowSize is usually set to something in the hundreds or thousands.
-	// That means we don't ever perform unsafe block consolidation (i.e., the safe head never advances) before the test is complete.
-	// To force this edge case to occur in the test, we decrease the SWS.
+	// Set a shorter Sequencer Window Size to force unsafe block consolidation to happen more often.
+	// A verifier (and the sequencer when it's determining the safe head) will have to read the entire sequencer window
+	// before advancing in the worst case. For the sake of tests running quickly, we minimize that worst case to 4 blocks.
 	deployConfig.SequencerWindowSize = 4
-	// Set low ChannelTimeout to ensure the batcher opens and closes a channel in the same block to avoid reorgs in
-	// unsafe block consolidation. Note that at the time of this writing, we're still seeing reorgs, so this likely isn't the silver bullet.
-	deployConfig.ChannelTimeout = 1
 	deployConfig.L1BlockTime = 2
 	deployConfig.L2BlockTime = 1
 

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -221,8 +221,10 @@ func depositE2E(t *testing.T, stack *e2e.StackConfig) {
 	require.NoError(t, err, "deposit tx")
 
 	// wait for tx to be processed
-	err = stack.WaitL2(1)
-	require.NoError(t, err)
+	// 1 L1 block to process the tx on L1 +
+	// 1 L2 block to process the tx on L2
+	require.NoError(t, stack.WaitL1(1))
+	require.NoError(t, stack.WaitL2(1))
 
 	// inspect L1 for deposit tx receipt and emitted TransactionDeposited event
 	receipt, err := l1Client.Client.TransactionReceipt(stack.Ctx, depositTx.Hash())
@@ -268,9 +270,8 @@ func requireEthIsMinted(t *testing.T, appchainClient *bftclient.HTTP) {
 		&perPage,
 		orderBy,
 	)
-
 	require.NoError(t, err, "search transactions")
-
+	require.NotNil(t, result)
 	require.NotEmpty(t, result.Txs, "mint_eth event not found")
 	t.Log("Monomer can mint_eth from L1 user deposits")
 }


### PR DESCRIPTION
Derivation will fail [here] if the sequencer does not post with the same address as the one specified in the onchain `SystemConfig`. Unfortunately, this cannot be counted as a fatal error during derivation since anyone can technically post batcher transactions. As a result, derivation will silently continue with empty batches, which manifests itself in rollbacks every time unsafe block consolidation is attempted when the sequencing window expires.

The `SystemConfig` is set when we convert the `DeployConfig` to a `RollupConfig`. Thus, to fix the issue, we set the `BatcherSenderAddress` in the `DeployConfig`.

[here]: https://github.com/ethereum-optimism/optimism/blob/24a8d3e06e61c7a8938dfb7a591345a437036381/op-node/rollup/derive/data_source.go#L110-L114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration for deployment settings to optimize performance during testing.
	- Introduced a new assignment for the batch sender's address, improving transaction processing.

- **Bug Fixes**
	- Adjusted logic for handling sequencer window size to facilitate unsafe block consolidation during tests.

- **Refactor**
	- Removed outdated settings related to channel timeout, streamlining the batching process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->