### PR TITLE
Capture root logger output in e2e tests

### DIFF
--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -71,6 +71,11 @@ func TestE2E(t *testing.T) {
 	if err := os.Mkdir(artifactsDirectoryName, 0o755); !errors.Is(err, os.ErrExist) {
 		require.NoError(t, err)
 	}
+
+	// Unfortunately, geth and parts of the OP Stack occasionally use the root logger.
+	// We capture the root logger's output in a separate file.
+	log.SetDefault(log.NewLogger(log.NewTerminalHandler(openLogFile(t, env, "root-logger"), false)))
+
 	opLogger := log.NewTerminalHandler(openLogFile(t, env, "op"), false)
 
 	prometheusCfg := &config.InstrumentationConfig{


### PR DESCRIPTION
This [would have helped us] find the reorg error much faster.

[would have helped us]: https://github.com/ethereum-optimism/optimism/pull/11756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new logging mechanism for enhanced output capture during end-to-end tests, improving debugging and analysis capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->