### PR TITLE
Derive L1BlockInfo with accurate L2BlockTime

### DIFF
--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -40,7 +40,7 @@ func (k *Keeper) processL1AttributesTx(ctx sdk.Context, txBytes []byte) (*derive
 		ctx.Logger().Error("First L1 tx must be a L1 attributes tx", "type", tx.Type())
 		return nil, types.WrapError(types.ErrInvalidL1Txs, "first L1 tx must be a L1 attributes tx, but got type %d", tx.Type())
 	}
-	l1blockInfo, err := derive.L1BlockInfoFromBytes(k.rollupCfg, 0, tx.Data())
+	l1blockInfo, err := derive.L1BlockInfoFromBytes(k.rollupCfg, uint64(ctx.BlockTime().Unix()), tx.Data())
 	if err != nil {
 		ctx.Logger().Error("Failed to derive L1 block info from L1 Info Deposit tx", "err", err, "txBytes", txBytes)
 		return nil, types.WrapError(types.ErrInvalidL1Txs, "failed to derive L1 block info from L1 Info Deposit tx: %v", err)


### PR DESCRIPTION
Derive L1BlockInfo with accurate L2BlockTime from the SDK context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved transaction processing accuracy by dynamically retrieving the current block time for L1 block information.
  
- **Bug Fixes**
	- Enhanced error handling for the derivation of L1 block info, ensuring issues are logged appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->