### PR TITLE
Add ParentHash to CometBFT header conversion

### DIFF
--- a/monomer.go
+++ b/monomer.go
@@ -60,10 +60,11 @@ type Header struct {
 
 func (h *Header) ToComet() *bfttypes.Header {
 	return &bfttypes.Header{
-		ChainID: h.ChainID.String(),
-		Height:  int64(h.Height),
-		Time:    time.Unix(int64(h.Time), 0),
-		AppHash: h.StateRoot.Bytes(),
+		ChainID:     h.ChainID.String(),
+		Height:      int64(h.Height),
+		Time:        time.Unix(int64(h.Time), 0),
+		LastBlockID: bfttypes.BlockID{Hash: h.ParentHash.Bytes()},
+		AppHash:     h.StateRoot.Bytes(),
 	}
 }
 

--- a/monomer_test.go
+++ b/monomer_test.go
@@ -47,10 +47,11 @@ func TestToComet(t *testing.T) {
 	cometHeader := header.ToComet()
 
 	require.Equal(t, &bfttypes.Header{
-		ChainID: header.ChainID.String(),
-		Height:  int64(header.Height),
-		Time:    time.Unix(int64(header.Time), 0),
-		AppHash: header.StateRoot.Bytes(),
+		ChainID:     header.ChainID.String(),
+		Height:      int64(header.Height),
+		Time:        time.Unix(int64(header.Time), 0),
+		AppHash:     header.StateRoot.Bytes(),
+		LastBlockID: bfttypes.BlockID{Hash: header.ParentHash.Bytes()},
 	}, cometHeader)
 }
 
@@ -156,6 +157,9 @@ func TestBlockToCometLikeBlock(t *testing.T) {
 			Time:    time.Unix(int64(block.Header.Time), 0),
 			Height:  int64(block.Header.Height),
 			AppHash: block.Header.StateRoot.Bytes(),
+			LastBlockID: bfttypes.BlockID{
+				Hash: block.Header.ParentHash.Bytes(),
+			},
 		},
 		Data: bfttypes.Data{
 			Txs: block.Txs,


### PR DESCRIPTION
- Include ParentHash in LastBlockID field of CometBFT header
- Set PartSetHeader Total to 0 and Hash to nil

This change ensures that the parent block information is properly represented when converting from Monomer to CometBFT headers. Including the ParentHash in the LastBlockID allows for correct block linking in
the CometBFT chain.

The PartSetHeader is set with Total: 0 and Hash: nil  because our implementation doesn't use CometBFT's block partitioning feature.

https://github.com/cometbft/cometbft/blob/v0.37.x/spec/core/data_structures.md#header

Fixes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced blockchain state information by adding a `LastBlockID` field to the header output, providing users with additional context about the last block's identifier.
  
- **Style**
	- Reformatted existing fields in the header output for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->