### PR TITLE
Fix withdrawal address conversion bug

### DIFF
--- a/bindings/L2ToL1MessagePasserExecuter.go
+++ b/bindings/L2ToL1MessagePasserExecuter.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -35,7 +34,7 @@ func NewL2ToL1MessagePasserExecuter(evm *vm.EVM) (*L2ToL1MessagePasserExecuter, 
 }
 
 func (e *L2ToL1MessagePasserExecuter) InitiateWithdrawal(
-	sender string,
+	sender common.Address,
 	amount *big.Int,
 	l1Address common.Address,
 	gasLimit *big.Int,
@@ -46,14 +45,8 @@ func (e *L2ToL1MessagePasserExecuter) InitiateWithdrawal(
 		return fmt.Errorf("create initiateWithdrawal data: %v", err)
 	}
 
-	senderCosmosAddress, err := sdk.AccAddressFromBech32(sender)
-	if err != nil {
-		return fmt.Errorf("convert sender to cosmos address: %v", err)
-	}
-	senderEthAddress := common.BytesToAddress(senderCosmosAddress.Bytes())
-
 	_, err = e.Call(&monomerevm.CallParams{
-		Sender: &senderEthAddress,
+		Sender: &sender,
 		Value:  amount,
 		Data:   data,
 	})

--- a/bindings/L2ToL1MessagePasserExecuter.go
+++ b/bindings/L2ToL1MessagePasserExecuter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -45,7 +46,11 @@ func (e *L2ToL1MessagePasserExecuter) InitiateWithdrawal(
 		return fmt.Errorf("create initiateWithdrawal data: %v", err)
 	}
 
-	senderEthAddress := common.HexToAddress(sender)
+	senderCosmosAddress, err := sdk.AccAddressFromBech32(sender)
+	if err != nil {
+		return fmt.Errorf("convert sender to cosmos address: %v", err)
+	}
+	senderEthAddress := common.BytesToAddress(senderCosmosAddress.Bytes())
 
 	_, err = e.Call(&monomerevm.CallParams{
 		Sender: &senderEthAddress,

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	bfttypes "github.com/cometbft/cometbft/types"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -336,9 +337,14 @@ func (b *Builder) storeWithdrawalMsgInEVM(
 		return nil, fmt.Errorf("get message nonce: %v", err)
 	}
 
+	senderCosmosAddress, err := sdk.AccAddressFromBech32(withdrawalMsg.GetSender())
+	if err != nil {
+		return nil, fmt.Errorf("convert sender to cosmos address: %v", err)
+	}
+
 	// Initiate the withdrawal in the Monomer ethereum state.
 	if err = executer.InitiateWithdrawal(
-		withdrawalMsg.GetSender(),
+		common.BytesToAddress(senderCosmosAddress.Bytes()),
 		withdrawalMsg.Value.BigInt(),
 		common.HexToAddress(withdrawalMsg.GetTarget()),
 		new(big.Int).SetBytes(withdrawalMsg.GasLimit),

--- a/evm/executer_test.go
+++ b/evm/executer_test.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -42,9 +41,7 @@ func TestL2ToL1MessagePasserExecuter(t *testing.T) {
 	executer, err := bindings.NewL2ToL1MessagePasserExecuter(setupEVM(t))
 	require.NoError(t, err)
 
-	cosmosSenderAddr, err := sdk.AccAddressFromBech32("cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh")
-	require.NoError(t, err)
-	ethSenderAddr := common.BytesToAddress(cosmosSenderAddr.Bytes())
+	sender := common.HexToAddress("0xabcdef12345")
 	amount := big.NewInt(500)
 	l1TargetAddress := common.HexToAddress("0x12345abcdef")
 	gasLimit := big.NewInt(100_000)
@@ -53,7 +50,7 @@ func TestL2ToL1MessagePasserExecuter(t *testing.T) {
 
 	withdrawalHash, err := crossdomain.NewWithdrawal(
 		nonce,
-		&ethSenderAddr,
+		&sender,
 		&l1TargetAddress,
 		amount,
 		gasLimit,
@@ -72,7 +69,7 @@ func TestL2ToL1MessagePasserExecuter(t *testing.T) {
 	require.Equal(t, nonce, initialMessageNonce)
 
 	// Initiate a withdrawal
-	err = executer.InitiateWithdrawal(cosmosSenderAddr.String(), amount, l1TargetAddress, gasLimit, data)
+	err = executer.InitiateWithdrawal(sender, amount, l1TargetAddress, gasLimit, data)
 	require.NoError(t, err)
 
 	// Check that the withdrawal hash is in the sentMessages mapping

--- a/evm/executer_test.go
+++ b/evm/executer_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -41,8 +42,9 @@ func TestL2ToL1MessagePasserExecuter(t *testing.T) {
 	executer, err := bindings.NewL2ToL1MessagePasserExecuter(setupEVM(t))
 	require.NoError(t, err)
 
-	cosmosSenderAddr := "abcdef12345"
-	ethSenderAddr := common.HexToAddress(cosmosSenderAddr)
+	cosmosSenderAddr, err := sdk.AccAddressFromBech32("cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh")
+	require.NoError(t, err)
+	ethSenderAddr := common.BytesToAddress(cosmosSenderAddr.Bytes())
 	amount := big.NewInt(500)
 	l1TargetAddress := common.HexToAddress("0x12345abcdef")
 	gasLimit := big.NewInt(100_000)
@@ -70,7 +72,7 @@ func TestL2ToL1MessagePasserExecuter(t *testing.T) {
 	require.Equal(t, nonce, initialMessageNonce)
 
 	// Initiate a withdrawal
-	err = executer.InitiateWithdrawal(cosmosSenderAddr, amount, l1TargetAddress, gasLimit, data)
+	err = executer.InitiateWithdrawal(cosmosSenderAddr.String(), amount, l1TargetAddress, gasLimit, data)
 	require.NoError(t, err)
 
 	// Check that the withdrawal hash is in the sentMessages mapping


### PR DESCRIPTION
Fixes a small bug in the withdrawals flow where cosmos addresses weren't being correctly converted from Bech32 before being converted to their ETH representation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the withdrawal initiation process by implementing robust address conversion for sender addresses, improving efficiency and clarity.

- **Bug Fixes**
	- Improved validation of sender addresses to ensure correct format during the withdrawal process.

- **Tests**
	- Updated test cases to streamline address handling, ensuring consistency and reliability in testing the withdrawal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->