### PR TITLE
Make config & genesis state data available to op-e2e.config init() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ e2e/artifacts
 # Ignore the forge artifacts and cache.
 bindings/artifacts
 bindings/cache
+
+# Ignore the op stack genesis outputs from make setup-e2e
+.devnet
+packages/contracts-bedrock/deploy-config/

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ setup-e2e:
 	$(MAKE) -C e2e/optimism install-geth && \
 	$(MAKE) -C e2e/optimism cannon-prestate && \
 	$(MAKE) -C e2e/optimism devnet-allocs && \
-	# Make genesis state and config available to op-e2e/config/init.go. See issue 207. && \
 	cp -r e2e/optimism/.devnet/ ./.devnet && \
 	mkdir -p ./packages/contracts-bedrock/deploy-config && \
 	cp ./e2e/optimism/packages/contracts-bedrock/deploy-config/devnetL1.json ./packages/contracts-bedrock/deploy-config/devnetL1.json

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ setup-e2e:
 	$(MAKE) -C e2e/optimism install-geth && \
 	$(MAKE) -C e2e/optimism cannon-prestate && \
 	$(MAKE) -C e2e/optimism devnet-allocs && \
-	# Make genesis state and config available to op-e2e/config/init.go. See issue #207. && \
+	# Make genesis state and config available to op-e2e/config/init.go. See issue 207. && \
 	cp -r e2e/optimism/.devnet/ ./.devnet && \
 	mkdir -p ./packages/contracts-bedrock/deploy-config && \
 	cp ./e2e/optimism/packages/contracts-bedrock/deploy-config/devnetL1.json ./packages/contracts-bedrock/deploy-config/devnetL1.json

--- a/Makefile
+++ b/Makefile
@@ -90,5 +90,9 @@ clean:
 .PHONY: setup-e2e
 setup-e2e:
 	$(MAKE) -C e2e/optimism install-geth && \
-		$(MAKE) -C e2e/optimism cannon-prestate && \
-		$(MAKE) -C e2e/optimism devnet-allocs
+	$(MAKE) -C e2e/optimism cannon-prestate && \
+	$(MAKE) -C e2e/optimism devnet-allocs && \
+	# Make genesis state and config available to op-e2e/config/init.go. See issue #207. && \
+	cp -r e2e/optimism/.devnet/ ./.devnet && \
+	mkdir -p ./packages/contracts-bedrock/deploy-config && \
+	cp ./e2e/optimism/packages/contracts-bedrock/deploy-config/devnetL1.json ./packages/contracts-bedrock/deploy-config/devnetL1.json


### PR DESCRIPTION
PR closes #207.

PR is somewhat clumsy. It:
- modifies `make.setup-e2e` to
  - make a copy of `./.devnet` in the root directory
  - make a copy of the `devnetL1.json` config file in `./packages/contracts-bedrock/deploy-config/`
- gitignores both sets of files

Both copied sets are referenced, at that location, by the `op-e2e.config.init()` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude unnecessary development and deployment files.
	- Enhanced the `setup-e2e` process in the Makefile for improved end-to-end testing setup, ensuring necessary configuration files are readily available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->