### PR TITLE
Remove `ToWithdrawalTx` helper

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/polymerdao/monomer/testutils"
 	"github.com/polymerdao/monomer/utils"
 	"github.com/polymerdao/monomer/x/rollup/types"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -315,13 +316,14 @@ func TestBuildRollupTxs(t *testing.T) {
 	require.NotNil(t, depositTxETH.To(), "Deposit transaction must have a 'to' address")
 
 	cosmAddr := utils.EvmToCosmosAddress(*depositTxETH.To())
-	withdrawalTx := testapp.ToWithdrawalTx(
-		t,
-		cosmAddr.String(),
-		common.HexToAddress("0x12345abcde").String(),
-		math.NewIntFromBigInt(depositTxETH.Value()),
-		big.NewInt(100_000),
-	)
+	withdrawalTx := testapp.ToTx(t,
+		&rolluptypes.MsgInitiateWithdrawal{
+			Sender:   cosmAddr.String(),
+			Target:   common.HexToAddress("0x12345abcde").String(),
+			Value:    math.NewIntFromBigInt(depositTxETH.Value()),
+			GasLimit: big.NewInt(100_000).Bytes(),
+			Data:     []byte{},
+		})
 
 	b := builder.New(
 		env.pool,

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/polymerdao/monomer/testutils"
 	"github.com/polymerdao/monomer/utils"
 	"github.com/polymerdao/monomer/x/rollup/types"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -317,7 +316,7 @@ func TestBuildRollupTxs(t *testing.T) {
 
 	cosmAddr := utils.EvmToCosmosAddress(*depositTxETH.To())
 	withdrawalTx := testapp.ToTx(t,
-		&rolluptypes.MsgInitiateWithdrawal{
+		&types.MsgInitiateWithdrawal{
 			Sender:   cosmAddr.String(),
 			Target:   common.HexToAddress("0x12345abcde").String(),
 			Value:    math.NewIntFromBigInt(depositTxETH.Value()),

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -315,9 +315,8 @@ func TestBuildRollupTxs(t *testing.T) {
 	require.NotNil(t, depositTxETH.To(), "Deposit transaction must have a 'to' address")
 
 	cosmAddr := utils.EvmToCosmosAddress(*depositTxETH.To())
-	withdrawalTx := testapp.ToTx(t,
-		&types.MsgInitiateWithdrawal{
-			Sender:   cosmAddr.String(),
+	withdrawalTx := testapp.ToTx(t, &types.MsgInitiateWithdrawal{
+		Sender:   cosmAddr.String(),
 			Target:   common.HexToAddress("0x12345abcde").String(),
 			Value:    math.NewIntFromBigInt(depositTxETH.Value()),
 			GasLimit: big.NewInt(100_000).Bytes(),

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -317,11 +317,11 @@ func TestBuildRollupTxs(t *testing.T) {
 	cosmAddr := utils.EvmToCosmosAddress(*depositTxETH.To())
 	withdrawalTx := testapp.ToTx(t, &types.MsgInitiateWithdrawal{
 		Sender:   cosmAddr.String(),
-			Target:   common.HexToAddress("0x12345abcde").String(),
-			Value:    math.NewIntFromBigInt(depositTxETH.Value()),
-			GasLimit: big.NewInt(100_000).Bytes(),
-			Data:     []byte{},
-		})
+		Target:   common.HexToAddress("0x12345abcde").String(),
+		Value:    math.NewIntFromBigInt(depositTxETH.Value()),
+		GasLimit: big.NewInt(100_000).Bytes(),
+		Data:     []byte{},
+	})
 
 	b := builder.New(
 		env.pool,

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -324,13 +324,14 @@ func rollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	// initiate the withdrawal of the deposited amount on L2
 	withdrawalTxResult, err := stack.L2Client.BroadcastTxAsync(
 		stack.Ctx,
-		testapp.ToWithdrawalTx(
-			t,
-			utils.EvmToCosmosAddress(*withdrawalTx.Sender).String(),
-			withdrawalTx.Target.String(),
-			math.NewIntFromBigInt(withdrawalTx.Value),
-			withdrawalTx.GasLimit,
-		),
+		testapp.ToTx(t,
+			&rolluptypes.MsgInitiateWithdrawal{
+				Sender:   utils.EvmToCosmosAddress(*withdrawalTx.Sender).String(),
+				Target:   withdrawalTx.Target.String(),
+				Value:    math.NewIntFromBigInt(withdrawalTx.Value),
+				GasLimit: withdrawalTx.GasLimit.Bytes(),
+				Data:     []byte{},
+			}),
 	)
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, withdrawalTxResult.Code)

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -326,11 +326,11 @@ func rollupFlow(t *testing.T, stack *e2e.StackConfig) {
 		stack.Ctx,
 		testapp.ToTx(t, &rolluptypes.MsgInitiateWithdrawal{
 			Sender:   utils.EvmToCosmosAddress(*withdrawalTx.Sender).String(),
-				Target:   withdrawalTx.Target.String(),
-				Value:    math.NewIntFromBigInt(withdrawalTx.Value),
-				GasLimit: withdrawalTx.GasLimit.Bytes(),
-				Data:     []byte{},
-			}),
+			Target:   withdrawalTx.Target.String(),
+			Value:    math.NewIntFromBigInt(withdrawalTx.Value),
+			GasLimit: withdrawalTx.GasLimit.Bytes(),
+			Data:     []byte{},
+		}),
 	)
 	require.NoError(t, err)
 	require.Equal(t, abcitypes.CodeTypeOK, withdrawalTxResult.Code)

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -324,9 +324,8 @@ func rollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	// initiate the withdrawal of the deposited amount on L2
 	withdrawalTxResult, err := stack.L2Client.BroadcastTxAsync(
 		stack.Ctx,
-		testapp.ToTx(t,
-			&rolluptypes.MsgInitiateWithdrawal{
-				Sender:   utils.EvmToCosmosAddress(*withdrawalTx.Sender).String(),
+		testapp.ToTx(t, &rolluptypes.MsgInitiateWithdrawal{
+			Sender:   utils.EvmToCosmosAddress(*withdrawalTx.Sender).String(),
 				Target:   withdrawalTx.Target.String(),
 				Value:    math.NewIntFromBigInt(withdrawalTx.Value),
 				GasLimit: withdrawalTx.GasLimit.Bytes(),

--- a/testapp/helpers.go
+++ b/testapp/helpers.go
@@ -3,11 +3,9 @@ package testapp
 import (
 	"context"
 	"encoding/json"
-	"math/big"
 	"slices"
 	"testing"
 
-	"cosmossdk.io/math"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -15,7 +13,6 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/polymerdao/monomer/testapp/x/testmodule"
 	"github.com/polymerdao/monomer/testapp/x/testmodule/types"
-	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +50,7 @@ func MakeGenesisAppState(t *testing.T, app *App, kvs ...string) map[string]json.
 }
 
 func ToTestTx(t *testing.T, k, v string) []byte {
-	return toTx(t, &types.MsgSetValue{
+	return ToTx(t, &types.MsgSetValue{
 		// TODO use real addresses and enable the signature and gas checks.
 		// This is just a dummy address. The signature and gas checks are disabled in testapp.go,
 		// so this works for now.
@@ -63,17 +60,7 @@ func ToTestTx(t *testing.T, k, v string) []byte {
 	})
 }
 
-func ToWithdrawalTx(t *testing.T, cosmosAddr string, ethAddr string, amount math.Int, gasLimit *big.Int) []byte {
-	return toTx(t, &rolluptypes.MsgInitiateWithdrawal{
-		Sender:   cosmosAddr,
-		Target:   ethAddr,
-		Value:    amount,
-		GasLimit: gasLimit.Bytes(),
-		Data:     []byte{},
-	})
-}
-
-func toTx(t *testing.T, msg proto.Message) []byte {
+func ToTx(t *testing.T, msg proto.Message) []byte {
 	msgAny, err := codectypes.NewAnyWithValue(msg)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This pull request removes the `ToWithdrawalTx` helper function from the `testapp` package.
Fixes #209 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction creation for withdrawal requests with a more structured message format.

- **Bug Fixes**
	- Improved clarity and maintainability of transaction broadcasting logic.

- **Refactor**
	- Updated function visibility and removed unused functions to streamline the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->