### PR TITLE
Update golangci-lint to v1.61.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,6 +57,9 @@ linters-settings:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  gosec:
+    excludes:
+      - G115 #TODO: remove after fixing https://github.com/securego/gosec/issues/1212
 
 linters:
   disable-all: true
@@ -66,7 +69,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - gochecknoinits
     - goconst
     - gocritic

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ e2e:
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
This pull request updates the golangci-lint version to v1.61.0 and excludes the G115 issue from the gosec linter. The G115 issue is currently causing problems and will be removed once it is fixed.