### PR TITLE
Support ERC-20 deposits in x/rollup

### DIFF
--- a/bindings/erc20_deposit_args.go
+++ b/bindings/erc20_deposit_args.go
@@ -1,0 +1,25 @@
+package bindings
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type RelayMessageArgs struct {
+	Nonce       *big.Int
+	Sender      common.Address
+	Target      common.Address
+	Value       *big.Int
+	MinGasLimit *big.Int
+	Message     []byte
+}
+
+type FinalizeBridgeERC20Args struct {
+	RemoteToken common.Address
+	LocalToken  common.Address
+	From        common.Address
+	To          common.Address
+	Amount      *big.Int
+	ExtraData   []byte
+}

--- a/e2e/stack.go
+++ b/e2e/stack.go
@@ -46,7 +46,7 @@ type StackConfig struct {
 	Users                []*ecdsa.PrivateKey
 	L1Client             *L1Client
 	L1Deployments        *opgenesis.L1Deployments
-	L1Portal             *bindings.OptimismPortal
+	OptimismPortal       *bindings.OptimismPortal
 	L1StandardBridge     *opbindings.L1StandardBridge
 	L2OutputOracleCaller *bindings.L2OutputOracleCaller
 	L2Client             *bftclient.HTTP
@@ -234,7 +234,7 @@ func (s *stack) run(ctx context.Context, env *environment.Env) (*StackConfig, er
 		Ctx:                  ctx,
 		L1Client:             l1Client,
 		L1Deployments:        ope2econfig.L1Deployments,
-		L1Portal:             opPortal,
+		OptimismPortal:       opPortal,
 		L1StandardBridge:     l1StandardBridge,
 		L2OutputOracleCaller: l2OutputOracleCaller,
 		L2Client:             l2Client,

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -265,7 +265,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 
 	// send user Deposit Tx
 	depositAmount := big.NewInt(params.Ether)
-	depositTx, err := stack.L1Portal.DepositTransaction(
+	depositTx, err := stack.OptimismPortal.DepositTransaction(
 		createL1TransactOpts(t, stack, userPrivKey, l1signer, l1GasLimit, depositAmount),
 		userAddress,
 		big.NewInt(0),
@@ -287,7 +287,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NotNil(t, receipt, "deposit tx receipt")
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "deposit tx reverted")
 
-	depositLogs, err := stack.L1Portal.FilterTransactionDeposited(
+	depositLogs, err := stack.OptimismPortal.FilterTransactionDeposited(
 		&bind.FilterOpts{
 			Start:   0,
 			End:     nil,
@@ -357,7 +357,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NoError(t, err)
 
 	// send a withdrawal proving tx to prove the withdrawal on L1
-	proveWithdrawalTx, err := stack.L1Portal.ProveWithdrawalTransaction(
+	proveWithdrawalTx, err := stack.OptimismPortal.ProveWithdrawalTransaction(
 		createL1TransactOpts(t, stack, userPrivKey, l1signer, l1GasLimit, nil),
 		withdrawalTx.WithdrawalTransaction(),
 		provenWithdrawalParams.L2OutputIndex,
@@ -377,7 +377,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 
 	withdrawalTxHash, err := withdrawalTx.Hash()
 	require.NoError(t, err)
-	proveWithdrawalLogs, err := stack.L1Portal.FilterWithdrawalProven(
+	proveWithdrawalLogs, err := stack.OptimismPortal.FilterWithdrawalProven(
 		&bind.FilterOpts{
 			Start:   0,
 			End:     nil,
@@ -401,7 +401,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NoError(t, err)
 
 	// send a withdrawal finalizing tx to finalize the withdrawal on L1
-	finalizeWithdrawalTx, err := stack.L1Portal.FinalizeWithdrawalTransaction(
+	finalizeWithdrawalTx, err := stack.OptimismPortal.FinalizeWithdrawalTransaction(
 		createL1TransactOpts(t, stack, userPrivKey, l1signer, l1GasLimit, nil),
 		withdrawalTx.WithdrawalTransaction(),
 	)
@@ -416,7 +416,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NotNil(t, receipt, "finalize withdrawal tx receipt")
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "finalize withdrawal tx failed")
 
-	finalizeWithdrawalLogs, err := stack.L1Portal.FilterWithdrawalFinalized(
+	finalizeWithdrawalLogs, err := stack.OptimismPortal.FilterWithdrawalFinalized(
 		&bind.FilterOpts{
 			Start:   0,
 			End:     nil,
@@ -515,7 +515,7 @@ func erc20RollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NoError(t, err)
 
 	// check that the deposit tx went through the OptimismPortal successfully
-	_, err = receipts.FindLog(depositReceipt.Logs, stack.L1Portal.ParseTransactionDeposited)
+	_, err = receipts.FindLog(depositReceipt.Logs, stack.OptimismPortal.ParseTransactionDeposited)
 	require.NoError(t, err, "should emit deposit event")
 
 	// assert the user's bridged WETH is no longer on L1

--- a/x/rollup/keeper/deposits.go
+++ b/x/rollup/keeper/deposits.go
@@ -1,16 +1,24 @@
 package keeper
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
+	"strings"
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	opbindings "github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/polymerdao/monomer"
+	"github.com/polymerdao/monomer/bindings"
 	"github.com/polymerdao/monomer/utils"
 	"github.com/polymerdao/monomer/x/rollup/types"
 	"github.com/samber/lo"
@@ -102,19 +110,82 @@ func (k *Keeper) processL1UserDepositTxs(
 			return nil, types.WrapError(types.ErrMintETH, "failed to mint ETH for cosmosAddress: %v; err: %v", cosmAddr, err)
 		}
 		mintEvents = append(mintEvents, *mintEvent)
+
+		// TODO: remove hardcoded address once a genesis state is configured
+		// Convert the L1CrossDomainMessenger address to its L2 aliased address
+		aliasedL1CrossDomainMessengerAddress := crossdomain.ApplyL1ToL2Alias(common.HexToAddress("0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"))
+
+		// Check if the tx is a cross domain message from the aliased L1CrossDomainMessenger address
+		if from == aliasedL1CrossDomainMessengerAddress && tx.Data() != nil {
+			erc20mintEvent, err := k.parseAndExecuteCrossDomainMessage(ctx, tx.Data())
+			// TODO: Investigate when to return an error if a cross domain message can't be parsed or executed - look at OP Spec
+			if err != nil {
+				ctx.Logger().Error("Failed to parse or execute cross domain message", "err", err)
+				return nil, types.WrapError(types.ErrInvalidL1Txs, "failed to parse or execute cross domain message: %v", err)
+			} else {
+				mintEvents = append(mintEvents, *erc20mintEvent)
+			}
+		}
 	}
 
 	return mintEvents, nil
+}
+
+// parseAndExecuteCrossDomainMessage parses the tx data of a cross domain message and applies state transitions for recognized messages.
+// Currently, only finalizeBridgeERC20 messages from the L1StandardBridge are recognized for minting ERC-20 tokens on the Cosmos chain.
+// If a message is not recognized, it returns nil and does not error.
+func (k *Keeper) parseAndExecuteCrossDomainMessage(ctx sdk.Context, txData []byte) (*sdk.Event, error) { //nolint:gocritic // hugeParam
+	crossDomainMessengerABI, err := abi.JSON(strings.NewReader(opbindings.CrossDomainMessengerMetaData.ABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CrossDomainMessenger ABI: %v", err)
+	}
+	standardBridgeABI, err := abi.JSON(strings.NewReader(opbindings.StandardBridgeMetaData.ABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse StandardBridge ABI: %v", err)
+	}
+
+	var relayMessage bindings.RelayMessageArgs
+	if err = unpackInputsIntoInterface(&crossDomainMessengerABI, "relayMessage", txData, &relayMessage); err != nil {
+		return nil, fmt.Errorf("failed to unpack tx data into relayMessage interface: %v", err)
+	}
+
+	// Check if the relayed message is a finalizeBridgeERC20 message from the L1StandardBridge
+	if bytes.Equal(relayMessage.Message[:4], standardBridgeABI.Methods["finalizeBridgeERC20"].ID) {
+		var finalizeBridgeERC20 bindings.FinalizeBridgeERC20Args
+		if err = unpackInputsIntoInterface(
+			&standardBridgeABI,
+			"finalizeBridgeERC20",
+			relayMessage.Message,
+			&finalizeBridgeERC20,
+		); err != nil {
+			return nil, fmt.Errorf("failed to unpack relay message into finalizeBridgeERC20 interface: %v", err)
+		}
+
+		// Mint the ERC-20 token to the specified Cosmos address
+		mintEvent, err := k.mintERC20(
+			ctx,
+			utils.EvmToCosmosAddress(finalizeBridgeERC20.To),
+			finalizeBridgeERC20.RemoteToken.String(),
+			sdkmath.NewIntFromBigInt(finalizeBridgeERC20.Amount),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to mint ERC-20 token: %v", err)
+		}
+
+		return mintEvent, nil
+	}
+
+	return nil, fmt.Errorf("tx data not recognized as a cross domain message: %v", txData)
 }
 
 // mintETH mints ETH to an account where the amount is in wei and returns the associated event.
 func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.Int) (*sdk.Event, error) { //nolint:gocritic // hugeParam
 	coin := sdk.NewCoin(types.ETH, amount)
 	if err := k.bankkeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(coin)); err != nil {
-		return nil, fmt.Errorf("failed to mint deposit coins to the rollup module: %v", err)
+		return nil, fmt.Errorf("failed to mint ETH deposit coins to the rollup module: %v", err)
 	}
 	if err := k.bankkeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, sdk.NewCoins(coin)); err != nil {
-		return nil, fmt.Errorf("failed to send deposit coins from rollup module to user account %v: %v", addr, err)
+		return nil, fmt.Errorf("failed to send ETH deposit coins from rollup module to user account %v: %v", addr, err)
 	}
 
 	mintEvent := sdk.NewEvent(
@@ -125,4 +196,60 @@ func (k *Keeper) mintETH(ctx sdk.Context, addr sdk.AccAddress, amount sdkmath.In
 	)
 
 	return &mintEvent, nil
+}
+
+// mintERC20 mints a bridged ERC-20 token to an account and returns the associated event.
+func (k *Keeper) mintERC20(
+	ctx sdk.Context, //nolint:gocritic // hugeParam
+	userAddr sdk.AccAddress,
+	erc20addr string,
+	amount sdkmath.Int,
+) (*sdk.Event, error) {
+	// use the "erc20/{l1erc20addr}" format for the coin denom
+	coin := sdk.NewCoin("erc20/"+erc20addr[2:], amount)
+	if err := k.bankkeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(coin)); err != nil {
+		return nil, fmt.Errorf("failed to mint ERC-20 deposit coins to the rollup module: %v", err)
+	}
+	if err := k.bankkeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, userAddr, sdk.NewCoins(coin)); err != nil {
+		return nil, fmt.Errorf("failed to send ERC-20 deposit coins from rollup module to user account %v: %v", userAddr, err)
+	}
+
+	mintEvent := sdk.NewEvent(
+		types.EventTypeMintERC20,
+		sdk.NewAttribute(types.AttributeKeyL1DepositTxType, types.L1UserDepositTxType),
+		sdk.NewAttribute(types.AttributeKeyToCosmosAddress, userAddr.String()),
+		sdk.NewAttribute(types.AttributeKeyERC20Address, erc20addr),
+		sdk.NewAttribute(types.AttributeKeyValue, hexutil.Encode(amount.BigInt().Bytes())),
+	)
+
+	return &mintEvent, nil
+}
+
+// unpackInputsIntoInterface unpacks the input data of a function call into an interface. This function behaves
+// similarly to the geth abi UnpackIntoInterface function but unpacks method inputs instead of outputs.
+func unpackInputsIntoInterface(contractABI *abi.ABI, methodName string, inputData []byte, outputInterface interface{}) error {
+	method := contractABI.Methods[methodName]
+
+	// Check if the function selector matches the method ID
+	functionSelector := inputData[:4]
+	if !bytes.Equal(functionSelector, method.ID) {
+		return fmt.Errorf("unexpected function selector: got %x, expected %x", functionSelector, method.ID)
+	}
+
+	inputs, err := method.Inputs.Unpack(inputData[4:])
+	if err != nil {
+		return fmt.Errorf("failed to unpack input data: %v", err)
+	}
+
+	outputVal := reflect.ValueOf(outputInterface).Elem()
+	for i, input := range inputs {
+		field := outputVal.Field(i)
+		if field.CanSet() {
+			val := reflect.ValueOf(input)
+			field.Set(val)
+		} else {
+			return fmt.Errorf("field %d can not be set for method %v", i, methodName)
+		}
+	}
+	return nil
 }

--- a/x/rollup/types/events.go
+++ b/x/rollup/types/events.go
@@ -11,10 +11,12 @@ const (
 	AttributeKeyGasLimit          = "gas_limit"
 	AttributeKeyData              = "data"
 	AttributeKeyNonce             = "nonce"
+	AttributeKeyERC20Address      = "erc20_address"
 
 	L1UserDepositTxType = "l1_user_deposit"
 
 	EventTypeMintETH             = "mint_eth"
+	EventTypeMintERC20           = "mint_erc20"
 	EventTypeBurnETH             = "burn_eth"
 	EventTypeWithdrawalInitiated = "withdrawal_initiated"
 )


### PR DESCRIPTION
Adds support for ERC-20 deposits by parsing the deposit tx data. ERC-20 tokens are minted on L2 in the `erc20/{L1 ERC-20 address}` format.

Safeguards are in place to ensure that the deposit tx originated from the L1CrossDomainMessenger so that users can't forge tx data to mint unlimited ERC-20 tokens.

`x/rollup` integration tests and e2e tests with ERC-20 deposits were added to verify the deposit was successful.

This is an initial increment to get a functional implementation for ERC-20 deposits. Future work to either add a genesis state to `x/rollup` to contain the `L1CrossDomainMessenger` address or to extract the ERC-20 deposit logic to a new cosmos module will be done in a future increment.

Closes https://github.com/polymerdao/monomer/issues/210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced structures for managing Ethereum ERC20 token deposits and relay messaging.
	- Enhanced testing suite with specific functions for handling ETH and ERC20 token deposits.
	- Added support for minting ERC20 tokens and processing cross-domain messages.
	- Improved integration with Ethereum Layer 1 components.
	- Expanded event handling capabilities to include ERC20 token operations.

- **Bug Fixes**
	- Improved error handling and logging in transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->