### PR TITLE
Add warning message if `GoImports` fails

### DIFF
--- a/monogen/monogen.go
+++ b/monogen/monogen.go
@@ -83,9 +83,8 @@ func Generate(ctx context.Context, appDirPath, goModulePath, addressPrefix strin
 	if err := gocmd.Fmt(ctx, appDir); err != nil {
 		return fmt.Errorf("go fmt: %v", err)
 	}
-	err = gocmd.GoImports(ctx, appDir) // From ignite: goimports installation could fail, so ignore the error
-	if err != nil {
-		fmt.Printf("Warning: goimports failed: %v\n", err)
+	if  err := gocmd.GoImports(ctx, appDir); err != nil {
+		return fmt.Errorf("run goimports: %v", err)
 	}
 	if err := gocmd.ModTidy(ctx, appDir); err != nil {
 		return fmt.Errorf("go mod tidy: %v", err)

--- a/monogen/monogen.go
+++ b/monogen/monogen.go
@@ -83,7 +83,10 @@ func Generate(ctx context.Context, appDirPath, goModulePath, addressPrefix strin
 	if err := gocmd.Fmt(ctx, appDir); err != nil {
 		return fmt.Errorf("go fmt: %v", err)
 	}
-	_ = gocmd.GoImports(ctx, appDir) // From ignite: goimports installation could fail, so ignore the error
+	err = gocmd.GoImports(ctx, appDir) // From ignite: goimports installation could fail, so ignore the error
+	if err != nil {
+		fmt.Printf("Warning: goimports failed: %v\n", err)
+	}
 	if err := gocmd.ModTidy(ctx, appDir); err != nil {
 		return fmt.Errorf("go mod tidy: %v", err)
 	}

--- a/monogen/monogen.go
+++ b/monogen/monogen.go
@@ -83,7 +83,7 @@ func Generate(ctx context.Context, appDirPath, goModulePath, addressPrefix strin
 	if err := gocmd.Fmt(ctx, appDir); err != nil {
 		return fmt.Errorf("go fmt: %v", err)
 	}
-	if  err := gocmd.GoImports(ctx, appDir); err != nil {
+	if err := gocmd.GoImports(ctx, appDir); err != nil {
 		return fmt.Errorf("run goimports: %v", err)
 	}
 	if err := gocmd.ModTidy(ctx, appDir); err != nil {


### PR DESCRIPTION
This pull request adds a warning message if the `GoImports` command fails during the code generation process. Previously, the error was ignored, but now a warning is printed to alert the user. This helps to identify potential issues with the `GoImports` installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for the `goimports` operation, providing feedback when it fails during the generation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->