### PR TITLE
Add go-wrapper.sh script for disabling checklinkname in go1.23.0 and higher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COVER_OUT ?= cover.out
 COVER_HTML ?= cover.html
 SCRIPTS_PATH ?= scripts
 BIN ?= bin
-GO_WRAPPER := $(SCRIPTS_PATH)/go-wrapper.sh
+GO_WRAPPER ?= $(SCRIPTS_PATH)/go-wrapper.sh
 
 E2E_ARTIFACTS_PATH ?= e2e/artifacts
 E2E_STATE_SETUP_PATH ?= e2e/optimism/.devnet

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ COVER_OUT ?= cover.out
 COVER_HTML ?= cover.html
 SCRIPTS_PATH ?= scripts
 BIN ?= bin
+GO_WRAPPER := $(SCRIPTS_PATH)/go-wrapper.sh
 
 E2E_ARTIFACTS_PATH ?= e2e/artifacts
 E2E_STATE_SETUP_PATH ?= e2e/optimism/.devnet
@@ -16,15 +17,15 @@ monogen:
 
 .PHONY: test
 test:
-	go test -short ./...
+	$(GO_WRAPPER) test -short ./...
 
 .PHONY: test-all
 test-all:
-	go test ./...
+	$(GO_WRAPPER) test ./...
 
 .PHONY: e2e
 e2e:
-	go test -v ./e2e \
+	$(GO_WRAPPER) test -v ./e2e \
 	-l1-allocs ./optimism/.devnet/allocs-l1.json \
 	-l2-allocs-dir ./optimism/.devnet/ \
 	-l1-deployments ./optimism/.devnet/addresses.json \
@@ -77,7 +78,7 @@ gen-mocks:
 	mockgen -source=x/rollup/types/expected_keepers.go -package testutil -destination x/rollup/testutil/expected_keepers_mocks.go
 
 $(COVER_OUT):
-	go test -short ./... -coverprofile=$@ -covermode=atomic -coverpkg=./...
+	$(GO_WRAPPER) test -short ./... -coverprofile=$@ -covermode=atomic -coverpkg=./...
 
 .PHONY: check-cover
 check-cover: $(COVER_OUT)

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Because we transitively depend on github.com/fjl/memsize, we need to disable checklinkname in go1.23.0 and higher.
+goVersion=$(go env GOVERSION)
+if [[ $goVersion > go1.23.0 || $goVersion == go1.23.0 ]]; then
+    exec go "$@" -ldflags=-checklinkname=0
+else
+    exec go "$@"
+fi

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 # Because we transitively depend on github.com/fjl/memsize, we need to disable checklinkname in go1.23.0 and higher.
 goVersion=$(go env GOVERSION)
 if [[ $goVersion > go1.23.0 || $goVersion == go1.23.0 ]]; then


### PR DESCRIPTION
Fixes #228

This pull request adds a new script, go-wrapper.sh, which is used to disable checklinkname in go1.23.0 and higher versions. This script is necessary because of a dependency on github.com/fjl/memsize. The script checks the Go version and sets the appropriate ldflags to disable checklinkname if the version is go1.23.0 or higher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new shell script to manage Go command execution and ensure compatibility with Go version 1.23.0 and higher.
	- Standardized testing commands in the Makefile to utilize a new variable for enhanced consistency.
	- Added unit tests for the `ProofAPI` functionality within the Ethereum API, covering various scenarios and edge cases.

- **Bug Fixes**
	- Addressed compatibility issues with Go version 1.23.0 and higher through the wrapper script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->