### PR TITLE
Add keplr integration for L2 devnet chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ e2e:
 	-l1-deployments ./optimism/.devnet/addresses.json \
 	-deploy-config ./optimism/packages/contracts-bedrock/deploy-config/devnetL1.json
 
+.PHONY: keplr-integration
+keplr-integration:
+	go run github.com/eliben/static-server@v1.3.0 -port=0 e2e/keplr
+
 .PHONY: install-golangci-lint
 install-golangci-lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1

--- a/e2e/keplr/index.html
+++ b/e2e/keplr/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Keplr Integration</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Roboto', sans-serif;
+            background-color: #f4f4f9;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+
+        .container {
+            text-align: center;
+            background-color: white;
+            padding: 40px;
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        h1 {
+            font-size: 2rem;
+            color: #333;
+            margin-bottom: 20px;
+        }
+
+        button {
+            background-color: #007bff;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 5px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        button:hover {
+            background-color: #0056b3;
+        }
+    </style>
+    <script src="keplr-integration.js?v=1.0" defer></script>
+</head>
+<body>
+<div class="container">
+    <h1>Monomer Devnet Keplr Integration</h1>
+    <button id="enable-keplr">Enable Keplr</button>
+</div>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const enableKeplrButton = document.getElementById("enable-keplr");
+        enableKeplrButton.addEventListener("click", function() {
+            runKeplrIntegration();
+        });
+    });
+</script>
+</body>
+</html>

--- a/e2e/keplr/keplr-integration.js
+++ b/e2e/keplr/keplr-integration.js
@@ -1,0 +1,125 @@
+const L1_CHAIN_CONFIG = {
+    chainId: "eip155:900",
+    chainName: "Ethereum (Monomer Devnet)",
+    rpc: "http://127.0.0.1:44601",
+    rest: "http://127.0.0.1:44601",
+    stakeCurrency: {
+        coinDenom: "ETH",
+        coinMinimalDenom: "wei",
+        coinDecimals: 18,
+        coinGeckoId: "ethereum",
+    },
+    bip44: {
+        coinType: 60,
+    },
+    evm: {
+        chainId: "900",
+        rpc: "http://127.0.0.1:44601",
+    },
+    currencies: [
+        {
+            coinDenom: "ETH",
+            coinMinimalDenom: "wei",
+            coinDecimals: 18,
+        },
+    ],
+    feeCurrencies: [
+        {
+            coinDenom: "ETH",
+            coinMinimalDenom: "wei",
+            coinDecimals: 18,
+        },
+    ],
+    gasPriceStep: {
+        low: 0.00000002,                // Minimum gas price (in ETH) for transactions (20 Gwei)
+        average: 0.00000005,            // Average gas price (50 Gwei)
+        high: 0.0000001,                // High gas price (100 Gwei)
+    },
+    features: ["eth-address-gen", "eth-key-sign"],
+}
+
+const L2_CHAIN_CONFIG = {
+    chainId: "1",
+    chainName: "L2 (Monomer Devnet)",
+    rpc: "http://127.0.0.1:26657",
+    rest: "http://127.0.0.1:1317",
+    stakeCurrency: {
+        coinDenom: "STAKE",
+        coinMinimalDenom: "stake",
+        coinDecimals: 6,
+    },
+    bip44: {
+        coinType: 118,
+    },
+    bech32Config: {
+        bech32PrefixAccAddr: "cosmos",
+        bech32PrefixAccPub: "cosmospub",
+        bech32PrefixValAddr: "cosmosvaloper",
+        bech32PrefixValPub: "cosmosvaloperpub",
+        bech32PrefixConsAddr: "cosmosvalcons",
+        bech32PrefixConsPub: "cosmosvalconspub",
+    },
+    currencies: [
+        {
+            coinDenom: "STAKE",
+            coinMinimalDenom: "stake",
+            coinDecimals: 6,
+        },
+    ],
+    feeCurrencies: [
+        {
+            coinDenom: "STAKE",
+            coinMinimalDenom: "stake",
+            coinDecimals: 6,
+        },
+    ],
+    gasPriceStep: {
+        low: 0.01,
+        average: 0.025,
+        high: 0.03,
+    },
+}
+
+async function runKeplrIntegration() {
+    try {
+        // Register the chains with Keplr
+        await registerChainsWithKeplr();
+
+        // Enable L1 and L2 chains in Keplr
+        await enableKeplr(L1_CHAIN_CONFIG.chainId);
+        await enableKeplr(L2_CHAIN_CONFIG.chainId);
+
+        console.log("Keplr is now interacting with the e2e test chains");
+    } catch (err) {
+        console.error("Error interacting with Keplr:", err);
+    }
+}
+
+async function enableKeplr(chainId) {
+    if (!window.keplr) {
+        console.error("Keplr wallet is not installed");
+        return;
+    }
+    // Enable the chain with Keplr
+    await window.keplr.enable(chainId.toString());
+    const offlineSigner = window.getOfflineSigner(chainId.toString());
+    const accounts = await offlineSigner.getAccounts();
+    console.log("Connected accounts:", accounts);
+}
+
+async function registerChainsWithKeplr() {
+    if (!window.keplr) {
+        console.error("Keplr wallet is not installed");
+        return;
+    }
+
+    try {
+        await window.keplr.experimentalSuggestChain(L1_CHAIN_CONFIG);
+
+        await window.keplr.experimentalSuggestChain(L2_CHAIN_CONFIG);
+
+        alert("L1 and L2 chains registered with Keplr");
+    } catch (error) {
+        console.error("Error registering chains:", error);
+    }
+}

--- a/integrations/integrations.go
+++ b/integrations/integrations.go
@@ -8,17 +8,22 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 	cometdb "github.com/cometbft/cometbft-db"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/server/api"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	servergrpc "github.com/cosmos/cosmos-sdk/server/grpc"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -29,8 +34,11 @@ import (
 	"github.com/polymerdao/monomer/genesis"
 	"github.com/polymerdao/monomer/monomerdb/localdb"
 	"github.com/polymerdao/monomer/node"
+	"github.com/polymerdao/monomer/utils"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -75,16 +83,17 @@ func StartCommandHandler(
 		return fmt.Errorf("start application: %v", err)
 	}
 
-	monomerCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	g, monomerCtx := getCtx(svrCtx)
 
 	// Would usually start a Comet node in-process here, but we replace the
 	// Comet node with a Monomer node.
-	if err := startInProcess(env, svrCtx, &clientCtx, monomerCtx, app, opts); err != nil {
+	if err = startInProcess(env, g, svrCtx, &svrCfg, &clientCtx, monomerCtx, app, opts); err != nil {
 		return fmt.Errorf("start Monomer node in-process: %v", err)
 	}
 
-	<-sigCh
+	if err = g.Wait(); err != nil {
+		return fmt.Errorf("unexpected error in errgroup: %v", err)
+	}
 
 	return nil
 }
@@ -125,7 +134,9 @@ func startApp(
 // We modify this function to start a Monomer node in-process instead of a Comet node.
 func startInProcess(
 	env *environment.Env,
+	g *errgroup.Group,
 	svrCtx *server.Context,
+	svrCfg *serverconfig.Config,
 	clientCtx *client.Context,
 	monomerCtx context.Context,
 	app servertypes.Application,
@@ -139,13 +150,28 @@ func startInProcess(
 		return fmt.Errorf("start Monomer node: %v", err)
 	}
 
-	if opts.PostSetup != nil {
-		var g errgroup.Group
-		if err := opts.PostSetup(svrCtx, *clientCtx, monomerCtx, &g); err != nil {
-			return fmt.Errorf("run post setup: %v", err)
+	// Add the tx service to the gRPC router if API or gRPC is enabled.
+	if svrCfg.API.Enable || svrCfg.GRPC.Enable {
+		app.RegisterTxService(*clientCtx)
+		app.RegisterTendermintService(*clientCtx)
+		app.RegisterNodeService(*clientCtx, *svrCfg)
+	}
+
+	var grpcSrv *grpc.Server
+	if svrCfg.GRPC.Enable {
+		grpcSrv, clientCtx, err = startGrpcServer(monomerCtx, g, svrCfg.GRPC, clientCtx, svrCtx, app)
+		if err != nil {
+			return fmt.Errorf("start gRPC server: %v", err)
 		}
-		if err := g.Wait(); err != nil {
-			return fmt.Errorf("unexpected error in PostSetup errgroup: %v", err)
+	}
+
+	if svrCfg.API.Enable {
+		startAPIServer(monomerCtx, g, svrCfg, clientCtx, svrCtx, app, svrCtx.Config.RootDir, grpcSrv)
+	}
+
+	if opts.PostSetup != nil {
+		if err = opts.PostSetup(svrCtx, *clientCtx, monomerCtx, g); err != nil {
+			return fmt.Errorf("run post setup: %v", err)
 		}
 	}
 
@@ -272,4 +298,99 @@ func startMonomerNode(
 	svrCtx.Logger.Info("Monomer started w/ CometBFT listener on", "address", cometListener.Addr())
 
 	return nil
+}
+
+// Starts the gRPC server if enabled in the server configuration.
+func startGrpcServer(
+	monomerCtx context.Context,
+	g *errgroup.Group,
+	config serverconfig.GRPCConfig,
+	clientCtx *client.Context,
+	svrCtx *server.Context,
+	app servertypes.Application,
+) (*grpc.Server, *client.Context, error) {
+	_, _, err := net.SplitHostPort(config.Address)
+	if err != nil {
+		return nil, clientCtx, fmt.Errorf("invalid gRPC server address: %v", err)
+	}
+
+	maxSendMsgSize := config.MaxSendMsgSize
+	if maxSendMsgSize == 0 {
+		maxSendMsgSize = serverconfig.DefaultGRPCMaxSendMsgSize
+	}
+
+	maxRecvMsgSize := config.MaxRecvMsgSize
+	if maxRecvMsgSize == 0 {
+		maxRecvMsgSize = serverconfig.DefaultGRPCMaxRecvMsgSize
+	}
+
+	// if gRPC is enabled, configure gRPC client for gRPC gateway
+	grpcClient, err := grpc.NewClient(
+		config.Address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.ForceCodec(codec.NewProtoCodec(clientCtx.InterfaceRegistry).GRPCCodec()),
+			grpc.MaxCallRecvMsgSize(maxRecvMsgSize),
+			grpc.MaxCallSendMsgSize(maxSendMsgSize),
+		),
+	)
+	if err != nil {
+		return nil, clientCtx, fmt.Errorf("failed to dial gRPC server: %v", err)
+	}
+
+	clientCtx = utils.Ptr(clientCtx.WithGRPCClient(grpcClient))
+
+	grpcSrv, err := servergrpc.NewGRPCServer(*clientCtx, app, config)
+	if err != nil {
+		return nil, clientCtx, fmt.Errorf("failed to create gRPC server: %v", err)
+	}
+
+	// Start the gRPC server in a goroutine. Note, the provided ctx will ensure
+	// that the server is gracefully shut down.
+	g.Go(func() error {
+		return servergrpc.StartGRPCServer(monomerCtx, svrCtx.Logger.With("module", "grpc-server"), config, grpcSrv)
+	})
+	return grpcSrv, clientCtx, nil
+}
+
+// Starts the API server if enabled in the server configuration.
+func startAPIServer(
+	monomerCtx context.Context,
+	g *errgroup.Group,
+	svrCfg *serverconfig.Config,
+	clientCtx *client.Context,
+	svrCtx *server.Context,
+	app servertypes.Application,
+	home string,
+	grpcSrv *grpc.Server,
+) {
+	clientCtx = utils.Ptr(clientCtx.WithHomeDir(home))
+
+	apiSrv := api.New(*clientCtx, svrCtx.Logger.With("module", "api-server"), grpcSrv)
+	app.RegisterAPIRoutes(apiSrv, svrCfg.API)
+
+	// Start the API server in a goroutine. Note, the provided ctx will ensure
+	// that the server is gracefully shut down.
+	g.Go(func() error {
+		return apiSrv.Start(monomerCtx, *svrCfg)
+	})
+}
+
+// getCtx returns a new errgroup and context for the Monomer node.
+func getCtx(svrCtx *server.Context) (*errgroup.Group, context.Context) {
+	ctx, cancelFn := context.WithCancel(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Listen for SIGINT and SIGTERM quit signals. When a signal is received,
+	// the cleanup function is called, indicating the caller can gracefully exit or
+	// return.
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	g.Go(func() error {
+		sig := <-sigCh
+		svrCtx.Logger.Info("Shutting down Monomer...", "signal", sig.String())
+		cancelFn()
+		return nil
+	})
+
+	return g, ctx
 }

--- a/integrations/integrations_test.go
+++ b/integrations/integrations_test.go
@@ -23,7 +23,7 @@ import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/gogoproto/grpc"
 	"github.com/polymerdao/monomer/e2e/url"
-	testapp "github.com/polymerdao/monomer/testapp"
+	"github.com/polymerdao/monomer/testapp"
 	"github.com/sourcegraph/conc"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -55,6 +55,8 @@ func TestStartCommandHandler(t *testing.T) {
 
 	// This flag must be set, because by default it's set to ""
 	svrCtx.Viper.Set("minimum-gas-prices", "0.025stake")
+	// Disable gRPC server (enabled by default)
+	svrCtx.Viper.Set("grpc.enable", false)
 	// This flag must be set to configure Monomer's Engine Websocket
 	viper.Set(monomerEngineWSFlag, "127.0.0.1:8089")
 
@@ -74,7 +76,7 @@ func TestStartCommandHandler(t *testing.T) {
 	var wg conc.WaitGroup
 	defer wg.Wait()
 	wg.Go(func() {
-		err := StartCommandHandler(svrCtx, clientCtx, mockAppCreator, inProcessConsensus, opts)
+		err = StartCommandHandler(svrCtx, clientCtx, mockAppCreator, inProcessConsensus, opts)
 		require.NoError(t, err)
 	})
 
@@ -94,6 +96,8 @@ func TestStartCommandHandler(t *testing.T) {
 	require.Equal(t, abcitypes.CodeTypeOK, putTx.Code, "put.Code is not OK")
 	require.EqualValues(t, bftTx.Hash(), putTx.Hash, "put.Hash is not equal to bftTx.Hash")
 	t.Log("Monomer Tx broadcasted successfully", "txHash", putTx.Hash)
+
+	// TODO: expose gRPC and API server in the integrated testapp and assert endpoints behave as expected
 
 	sigCh <- syscall.SIGINT
 }


### PR DESCRIPTION
Exposes the Cosmos [gRPC and API servers](https://docs.cosmos.network/v0.50/learn/advanced/grpc_rest) when starting a monomer node in process through the Monomer start command.

Also, creates a go script for bringing up a server for deploying Monomer devnet chain configs on Keplr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new integration for the Keplr wallet with support for Ethereum and Monomer Devnet.
	- Added a user interface for Keplr integration, featuring a styled button to enable the wallet.
  
- **Bug Fixes**
	- Enhanced error handling and graceful shutdown capabilities for the Monomer node.

- **Documentation**
	- Updated HTML and JavaScript files to improve user experience with the Keplr wallet integration.

- **Tests**
	- Adjusted server context configuration and error handling in tests to streamline processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->