### PR TITLE
Fix Comet /status RPC endpoint

### DIFF
--- a/comet/comet.go
+++ b/comet/comet.go
@@ -73,13 +73,13 @@ type HeadHeader interface {
 	HeadHeader() (*monomer.Header, error)
 }
 
-type Status struct {
+type StatusAPI struct {
 	blockstore HeadHeader
 	startBlock *bfttypes.Block
 }
 
-func NewStatus(blockStore HeadHeader, startBlock *bfttypes.Block) *Status {
-	return &Status{
+func NewStatusAPI(blockStore HeadHeader, startBlock *bfttypes.Block) *StatusAPI {
+	return &StatusAPI{
 		blockstore: blockStore,
 		startBlock: startBlock,
 	}
@@ -88,7 +88,7 @@ func NewStatus(blockStore HeadHeader, startBlock *bfttypes.Block) *Status {
 // Status returns CometBFT status including node info, pubkey, latest block hash, app hash, block height, and block
 // time.
 // More: https://docs.cometbft.com/main/rpc/#/ABCI/status
-func (s *Status) Status(_ *jsonrpctypes.Context) (*rpctypes.ResultStatus, error) {
+func (s *StatusAPI) Status(_ *jsonrpctypes.Context) (*rpctypes.ResultStatus, error) {
 	headHeader, err := s.blockstore.HeadHeader()
 	if err != nil {
 		return nil, err

--- a/comet/comet_test.go
+++ b/comet/comet_test.go
@@ -84,7 +84,7 @@ func TestStatus(t *testing.T) {
 			Time:    time.Now(),
 		},
 	}
-	statusAPI := comet.NewStatus(blockStore, startBlock)
+	statusAPI := comet.NewStatusAPI(blockStore, startBlock)
 	result, err := statusAPI.Status(&jsonrpctypes.Context{})
 	require.NoError(t, err)
 	require.Equal(t, &rpctypes.ResultStatus{

--- a/node/node.go
+++ b/node/node.go
@@ -170,7 +170,7 @@ func (n *Node) Run(ctx context.Context, env *environment.Env) error {
 		"health": cometserver.NewRPCFunc(func(_ *jsonrpctypes.Context) (*rpctypes.ResultHealth, error) {
 			return &rpctypes.ResultHealth{}, nil
 		}, ""),
-		"status": cometserver.NewRPCFunc(comet.NewStatus(n.blockdb, nil).Status, ""), // TODO start block
+		"status": cometserver.NewRPCFunc(comet.NewStatusAPI(n.blockdb, nil).Status, ""), // TODO start block
 
 		"abci_query": cometserver.NewRPCFunc(abci.Query, "path,data,height,prove"),
 		"abci_info":  cometserver.NewRPCFunc(abci.Info, "", cometserver.Cacheable()),


### PR DESCRIPTION
Currently, the CometBFT `/status` RPC endpoint errors out because no start block is provided. The head block on startup is passed into the status API as the earliest block to show up when hitting the `/status` endpoint.

In the future, a new DB method should be exposed to get the earliest stored block instead of using the head block on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `StatusAPI` for improved clarity in API interactions.
	- Enhanced the status retrieval process by utilizing the latest head block.

- **Bug Fixes**
	- Improved error handling in transaction broadcasts and retrieval processes.

- **Tests**
	- Expanded test cases to cover various functionalities, ensuring robust validation of the API's behavior.
	- Updated tests to reflect the new naming conventions and added checks for multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->