### PR TITLE
Move l1 address info to interact.md

### DIFF
--- a/docs/docs/build/create-an-app-with-monomer.md
+++ b/docs/docs/build/create-an-app-with-monomer.md
@@ -39,17 +39,16 @@ If using a Go version `<1.23.0`, run:
 go build -o testappd ./cmd/testappd
 ```
 
-If using a Go version `>=1.23.0`, run: 
+If using a Go version `>=1.23.0`, run:
 
 ```bash
 go build -ldflags=-checklinkname=0 -o testappd ./cmd/testappd
 ````
 
 Now that our application is configured, we can start the Monomer application by running the following command.
-Ensure that you specify the address of your L1 wallet address instead of `{your_l1_wallet_address}` to grant ETH to your L1 wallet on genesis.
 
 ```bash
-./testappd monomer start --minimum-gas-prices 0.01wei --monomer.dev-start --api.enable --monomer.dev.l1-user-address "{your_l1_wallet_address}"
+./testappd monomer start --minimum-gas-prices 0.01wei --monomer.dev-start --api.enable
 ````
 
 Congratulations! You've successfully integrated Monomer into your Cosmos SDK application.

--- a/docs/docs/build/interact.md
+++ b/docs/docs/build/interact.md
@@ -6,6 +6,13 @@ sidebar_position: 2
 
 This guide assumes you have a Monomer rollup chain running locally. If you don't, refer to the [prior tutorial](./create-an-app-with-monomer.md).
 
+We will need to have an account on L1 with funds.
+To give yourself funds on the devnet at genesis, run the devnet start command specified in the last tutorial with the `--monomer.dev.l1-user-address` flag:
+
+```bash
+./testappd monomer start --minimum-gas-prices 0.01wei --monomer.dev-start --api.enable --monomer.dev.l1-user-address "<address>"
+```
+
 ## Configuring L1 and L2 Wallets
 
 To interact with a Monomer rollup chain, you will need to configure wallets for both the L1 and L2 chains.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated setup and execution commands for creating a Monomer L2 application based on Go version.
	- Simplified command to start the Monomer application by removing L1 wallet address requirement.
	- Added instructions for interacting with Monomer rollup Devnet, including prerequisites for L1 account and funds.
	- Enhanced guidance on wallet integration and the role of the wallet setup server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->