### PR TITLE
Enable ETH deposits through L1StandardBridge

### DIFF
--- a/bindings/cross_domain_args.go
+++ b/bindings/cross_domain_args.go
@@ -15,6 +15,13 @@ type RelayMessageArgs struct {
 	Message     []byte
 }
 
+type FinalizeBridgeETHArgs struct {
+	From      common.Address
+	To        common.Address
+	Amount    *big.Int
+	ExtraData []byte
+}
+
 type FinalizeBridgeERC20Args struct {
 	RemoteToken common.Address
 	LocalToken  common.Address

--- a/e2e/stack_test.go
+++ b/e2e/stack_test.go
@@ -206,34 +206,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NotNil(t, receipt, "deposit tx receipt")
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "deposit tx reverted")
 
-	depositLogs, err := stack.OptimismPortal.FilterTransactionDeposited(
-		&bind.FilterOpts{
-			Start:   0,
-			End:     nil,
-			Context: stack.Ctx,
-		},
-		[]common.Address{userETHAddress},
-		[]common.Address{common.Address(userCosmosETHAddress)},
-		[]*big.Int{big.NewInt(0)},
-	)
-	require.NoError(t, err, "configuring 'TransactionDeposited' event listener")
-	require.True(t, depositLogs.Next(), "finding deposit event")
-	require.NoError(t, depositLogs.Close())
-
-	// get the user's balance after the deposit has been processed
-	balanceAfterDeposit, err := stack.L1Client.BalanceAt(stack.Ctx, userETHAddress, nil)
-	require.NoError(t, err)
-
-	//nolint:gocritic
-	// gasCost = gasUsed * gasPrice
-	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
-
-	//nolint:gocritic
-	// expectedBalance = balanceBeforeDeposit - depositAmount - gasCost
-	expectedBalance := new(big.Int).Sub(new(big.Int).Sub(balanceBeforeDeposit, depositAmount), gasCost)
-
-	// check that the user's balance has been updated on L1
-	require.Equal(t, expectedBalance, balanceAfterDeposit)
+	requireExpectedBalanceAfterDeposit(t, stack, receipt, userETHAddress, balanceBeforeDeposit, depositAmount)
 
 	userCosmosAddr, err := userCosmosETHAddress.Encode("e2e")
 	require.NoError(t, err)
@@ -256,24 +229,7 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	receipt, err = wait.ForReceiptOK(stack.Ctx, l1Client.Client, bridgeDepositTx.Hash())
 	require.NoError(t, err)
 
-	// check that the bridge deposit tx went through the OptimismPortal successfully
-	_, err = receipts.FindLog(receipt.Logs, stack.OptimismPortal.ParseTransactionDeposited)
-	require.NoError(t, err, "should emit deposit event")
-
-	// get the user's balance after the deposit has been processed
-	balanceAfterDeposit, err = stack.L1Client.BalanceAt(stack.Ctx, userETHAddress, nil)
-	require.NoError(t, err)
-
-	//nolint:gocritic
-	// gasCost = gasUsed * gasPrice
-	gasCost = new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
-
-	//nolint:gocritic
-	// expectedBalance = balanceBeforeDeposit - bridgeDepositAmount - gasCost
-	expectedBalance = new(big.Int).Sub(new(big.Int).Sub(balanceBeforeDeposit, bridgeDepositAmount), gasCost)
-
-	// check that the user's balance has been updated on L1
-	require.Equal(t, expectedBalance, balanceAfterDeposit)
+	requireExpectedBalanceAfterDeposit(t, stack, receipt, userETHAddress, balanceBeforeDeposit, bridgeDepositAmount)
 
 	// wait for tx to be processed on L2
 	require.NoError(t, stack.WaitL2(2))
@@ -415,12 +371,8 @@ func ethRollupFlow(t *testing.T, stack *e2e.StackConfig) {
 	require.NoError(t, err)
 
 	//nolint:gocritic
-	// gasCost = gasUsed * gasPrice
-	gasCost = new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
-
-	//nolint:gocritic
 	// expectedBalance = balanceBeforeFinalization + withdrawalAmount - gasCost
-	expectedBalance = new(big.Int).Sub(new(big.Int).Add(balanceBeforeFinalization, withdrawalAmount), gasCost)
+	expectedBalance := new(big.Int).Sub(new(big.Int).Add(balanceBeforeFinalization, withdrawalAmount), getGasCost(receipt))
 
 	// check that the user's balance has been updated on L1
 	require.Equal(t, expectedBalance, balanceAfterFinalization)
@@ -625,6 +577,35 @@ func requireERC20IsMinted(t *testing.T, stack *e2e.StackConfig, userAddress, tok
 	result := l2TxSearch(t, stack, query)
 
 	require.NotEmpty(t, result.Txs, "mint_erc20 event not found")
+}
+
+func requireExpectedBalanceAfterDeposit(
+	t *testing.T,
+	stack *e2e.StackConfig,
+	receipt *types.Receipt,
+	userETHAddress common.Address,
+	balanceBeforeDeposit, depositAmount *big.Int,
+) {
+	// check that the deposit tx went through the OptimismPortal successfully
+	_, err := receipts.FindLog(receipt.Logs, stack.OptimismPortal.ParseTransactionDeposited)
+	require.NoError(t, err, "should emit deposit event")
+
+	// get the user's balance after the deposit has been processed
+	balanceAfterDeposit, err := stack.L1Client.BalanceAt(stack.Ctx, userETHAddress, nil)
+	require.NoError(t, err)
+
+	//nolint:gocritic
+	// expectedBalance = balanceBeforeDeposit - bridgeDepositAmount - gasCost
+	expectedBalance := new(big.Int).Sub(new(big.Int).Sub(balanceBeforeDeposit, depositAmount), getGasCost(receipt))
+
+	// check that the user's balance has been updated on L1
+	require.Equal(t, expectedBalance, balanceAfterDeposit)
+}
+
+func getGasCost(receipt *types.Receipt) *big.Int {
+	//nolint:gocritic
+	// gasCost = gasUsed * gasPrice
+	return new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
 }
 
 func l2TxSearch(t *testing.T, stack *e2e.StackConfig, query string) *cometcore.ResultTxSearch {


### PR DESCRIPTION
Enable ETH deposits through L1StandardBridge cross domain messages. Follows the same flow as ERC-20 deposits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new type for handling ETH bridge deposits, improving transaction processing.
	- Enhanced deposit mechanism for Ethereum transactions, ensuring accurate balance updates post-deposit.
  
- **Bug Fixes**
	- Improved error handling for transaction processing, ensuring better reporting of issues.

- **Documentation**
	- Updated logging and variable names for clarity in transaction handling.

- **Tests**
	- Enhanced test coverage for ETH deposits and withdrawals, ensuring accurate balance assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->