### PR TITLE
Typo withdrawals.md

### DIFF
--- a/docs/docs/learn/withdrawals.md
+++ b/docs/docs/learn/withdrawals.md
@@ -38,6 +38,6 @@ For each observed event, the builder makes a corresponding `L2ToL1MessagePasserE
 
 The next step for a user is to obtain a proof of the withdrawal transaction.
 
-For compatability with the withdrawals process, Monomer uses the state root of its EVM sidecar state as the L2 state updated by the `op-proposer`. Monomer exposes the standard ethereum `GetProof` API endpoint for obtaining a merkle proof of withdrawal transactions registered in the EVM sidecar state.
+For compatibility with the withdrawals process, Monomer uses the state root of its EVM sidecar state as the L2 state updated by the `op-proposer`. Monomer exposes the standard ethereum `GetProof` API endpoint for obtaining a merkle proof of withdrawal transactions registered in the EVM sidecar state.
 
 With the withdrawal proof data, the user is now back to the L1 side of the OP Stack. The proof is submitted, and the withdrawal can be finalized after the rollup's challenge period.


### PR DESCRIPTION
This change corrects the spelling of "compatability" to "compatibility". The term "compatibility" is the correct and standard spelling in English, while "compatability" is a misspelling and does not appear in dictionaries.

Such an error in technical documentation can cause confusion and negatively impact the perception of the project, especially for developers who rely on accurate documentation. Additionally, proper spelling is crucial for maintaining a professional and polished appearance of the project, which enhances trust in the technical content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and corrected typographical errors in the withdrawal process documentation.
	- Corrected "compatability" to "compatibility" for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->