### PR TITLE
Only allow deposit messages from Monomer

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -8,7 +8,6 @@ import (
 
 	comettypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/utils"
 )
 
@@ -38,13 +37,6 @@ func (p *Pool) Enqueue(userTxn comettypes.Tx) (err error) {
 	// NOTE: we should do reads and writes on the same view. Right now they occur on separate views.
 	// Unfortunately, comet's DB interface doesn't support it.
 	// Moving to a different DB interface is left for future work.
-
-	// Attempt to adapt the Cosmos transaction to an Ethereum deposit transaction.
-	// If the adaptation succeeds, it indicates that the
-	// user transaction is a deposit transaction, which is not allowed in the pool.
-	if _, err := monomer.GetDepositTxs(userTxn); err == nil {
-		return errors.New("deposit txs are not allowed in the pool")
-	}
 
 	batch := p.db.NewBatch()
 	defer func() {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	comettypes "github.com/cometbft/cometbft/types"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/polymerdao/monomer"
 	"github.com/polymerdao/monomer/mempool"
 	"github.com/polymerdao/monomer/testutils"
 	"github.com/stretchr/testify/assert"
@@ -22,18 +20,6 @@ func TestMempool(t *testing.T) {
 
 		_, err = pool.Dequeue()
 		require.Error(t, err)
-	})
-
-	t.Run("deposit transaction", func(t *testing.T) {
-		l1AttributesTx, depositTx, _ := testutils.GenerateEthTxs(t)
-		l1AttributesTxBytes, err := l1AttributesTx.MarshalBinary()
-		require.NoError(t, err)
-		depositTxBytes, err := depositTx.MarshalBinary()
-		require.NoError(t, err)
-
-		cosmosTxs, err := monomer.AdaptPayloadTxsToCosmosTxs([]hexutil.Bytes{l1AttributesTxBytes, depositTxBytes})
-		require.NoError(t, err)
-		require.ErrorContains(t, pool.Enqueue(cosmosTxs[0]), "deposit txs are not allowed in the pool")
 	})
 
 	// enqueue multiple to empty

--- a/x/rollup/tx/helpers/ante.go
+++ b/x/rollup/tx/helpers/ante.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
@@ -43,6 +44,12 @@ func (a *AnteHandler) AnteHandle(
 		}
 		return newCtx, err
 	default: // Unfortunately, the Cosmos SDK does not export its default tx type.
+		for _, msg := range tx.GetMsgs() {
+			if _, ok := msg.(rolluptypes.DepositMsg); ok {
+				return ctx, errors.New("transaction contains deposit message")
+			}
+		}
+
 		newCtx, err := a.authAnteHandler(ctx, tx, simulate)
 		if err != nil {
 			return newCtx, fmt.Errorf("auth ante handle: %v", err)

--- a/x/rollup/tx/helpers/ante.go
+++ b/x/rollup/tx/helpers/ante.go
@@ -6,19 +6,18 @@ import (
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
-	rollupkeeper "github.com/polymerdao/monomer/x/rollup/keeper"
 	rolluptx "github.com/polymerdao/monomer/x/rollup/tx"
 	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
 
 type AnteHandler struct {
 	authAnteHandler sdktypes.AnteHandler
-	rollupKeeper    *rollupkeeper.Keeper
+	rollupKeeper    rolluptx.RollupKeeper
 }
 
 func NewAnteHandler(
 	options authante.HandlerOptions, //nolint:gocritic // hugeParam
-	rollupKeeper *rollupkeeper.Keeper,
+	rollupKeeper rolluptx.RollupKeeper,
 ) (*AnteHandler, error) {
 	authAnteHandler, err := authante.NewAnteHandler(options)
 	if err != nil {

--- a/x/rollup/tx/helpers/ante_test.go
+++ b/x/rollup/tx/helpers/ante_test.go
@@ -1,0 +1,71 @@
+package helpers_test
+
+import (
+	"testing"
+
+	storetypes "cosmossdk.io/store/types"
+	"cosmossdk.io/x/tx/signing"
+	"cosmossdk.io/x/tx/signing/direct"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authantetestutil "github.com/cosmos/cosmos-sdk/x/auth/ante/testutil"
+	authtestutil "github.com/cosmos/cosmos-sdk/x/auth/testutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/golang/mock/gomock"
+	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck
+	"github.com/polymerdao/monomer/testutils"
+	"github.com/polymerdao/monomer/x/rollup/tx/helpers"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type mockRollupKeeper struct{}
+
+func (mockRollupKeeper) GetL1BlockInfo(_ sdk.Context) (*rolluptypes.L1BlockInfo, error) { //nolint:gocritic // hugeParam
+	return &rolluptypes.L1BlockInfo{}, nil
+}
+
+type mockTx struct {
+	tx *sdktx.Tx
+}
+
+var _ sdk.Tx = (*mockTx)(nil)
+
+func (tx *mockTx) GetMsgs() []sdk.Msg {
+	return tx.tx.GetMsgs()
+}
+
+func (tx *mockTx) GetMsgsV2() ([]protoreflect.ProtoMessage, error) {
+	msgsV1 := tx.GetMsgs()
+	msgs := make([]protoreflect.ProtoMessage, 0, len(msgsV1))
+	for _, msgV1 := range msgsV1 {
+		msgs = append(msgs, protov1.MessageV2(msgV1))
+	}
+	return msgs, nil
+}
+
+func TestUserTransactionCannotContainDepositMesssage(t *testing.T) {
+	sdkCtx := testutil.DefaultContextWithDB(
+		t,
+		storetypes.NewKVStoreKey(rolluptypes.StoreKey),
+		storetypes.NewTransientStoreKey("transient_test"),
+	).Ctx
+	anteHandler, err := helpers.NewAnteHandler(authante.HandlerOptions{
+		AccountKeeper:   authantetestutil.NewMockAccountKeeper(gomock.NewController(t)),
+		BankKeeper:      authtestutil.NewMockBankKeeper(gomock.NewController(t)),
+		SignModeHandler: signing.NewHandlerMap(direct.SignModeHandler{}),
+	}, mockRollupKeeper{})
+	require.NoError(t, err)
+
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	for _, depositMsg := range []protov1.Message{&rolluptypes.MsgSetL1Attributes{}, &rolluptypes.MsgApplyUserDeposit{}} {
+		_, err := anteHandler.AnteHandle(sdkCtx, &mockTx{
+			tx: testutils.BuildSDKTx(t, "chainID", 0, 0, privKey, []protov1.Message{depositMsg}),
+		}, false)
+		require.ErrorContains(t, err, "transaction contains deposit message")
+	}
+}

--- a/x/rollup/tx/l1_data.go
+++ b/x/rollup/tx/l1_data.go
@@ -8,13 +8,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ethereum/go-ethereum/rlp"
-	rollupkeeper "github.com/polymerdao/monomer/x/rollup/keeper"
+	rolluptypes "github.com/polymerdao/monomer/x/rollup/types"
 )
+
+type RollupKeeper interface {
+	GetL1BlockInfo(ctx sdk.Context) (*rolluptypes.L1BlockInfo, error)
+}
 
 // L1DataAnteHandler will consume gas to compensate the sequencer for posting
 // the transaction to Ethereum. The gas cost is calculated based on the Ecotone
 // upgrade and the sequencer is expected to post the transaction using blobs.
-func L1DataAnteHandler(ctx sdk.Context, tx sdk.Tx, rollupKeeper *rollupkeeper.Keeper) (sdk.Context, error) { //nolint:gocritic // hugeparam
+func L1DataAnteHandler(ctx sdk.Context, tx sdk.Tx, rollupKeeper RollupKeeper) (sdk.Context, error) { //nolint:gocritic // hugeparam
 	if rollupKeeper == nil {
 		return ctx, errorsmod.Wrap(sdkerrors.ErrLogic, "rollup keeper is required for l1 data ante handler")
 	}

--- a/x/rollup/types/deposit_msg.go
+++ b/x/rollup/types/deposit_msg.go
@@ -1,0 +1,8 @@
+package types
+
+type DepositMsg interface {
+	isDeposit()
+}
+
+func (*MsgSetL1Attributes) isDeposit()  {}
+func (*MsgApplyUserDeposit) isDeposit() {}


### PR DESCRIPTION
Before, we were only blocking deposit transactions from the Monomer mempool. This meant that standard auth txs could contain deposit messages, minting arbitrary amounts of eth. We fix this by checking for deposit messages in all transactions in helpers/ante.go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for transactions containing deposit messages.
	- Introduced a new `DepositMsg` interface for better message type management.
	- Streamlined transaction creation process with new utility functions.

- **Bug Fixes**
	- Removed the handling of deposit transactions from the enqueueing process, simplifying transaction management.

- **Tests**
	- Added unit tests for the ante handler to ensure transactions with deposit messages are correctly rejected.
	- Simplified test suite by removing the test case for deposit transactions while maintaining validation for other transaction behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->