### PR TITLE
Add ERC-20 withdrawal e2e test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -30,7 +30,7 @@ var e2eTests = []struct {
 		run:  ethRollupFlow,
 	},
 	{
-		name: "ERC-20 L1 Deposits",
+		name: "ERC-20 L1 Deposits and L2 Withdrawals",
 		run:  erc20RollupFlow,
 	},
 	{


### PR DESCRIPTION
Adds an e2e test for initiating an ERC-20 withdrawal on L2 and then proving and finalizing the ERC-20 withdrawal on L1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded end-to-end testing for ERC-20 L1 deposits to include L2 withdrawals.
	- Enhanced functionality for Ethereum deposits and withdrawals in the rollup stack.
  
- **Bug Fixes**
	- Improved transaction handling with checks for successful completion of deposits and withdrawals.

- **Refactor**
	- Streamlined deposit and withdrawal processes for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->