### PR TITLE
fix: typos in documentation files

### DIFF
--- a/app/peptide/txstore/txstore.go
+++ b/app/peptide/txstore/txstore.go
@@ -69,7 +69,7 @@ func (t *txstore) rollbackOneBlock(batch dbm.Batch, height uint64) error {
 	// The indexer stores txs in its underlying DB by constructing a key that uses a combination
 	// of height, indexes and hardcoded labels. For more details, see how the keys are constructed here:
 	//    https://github.com/cometbft/cometbft/blob/v0.37.2/state/txindex/kv/kv.go#L640
-	// The iterator below is a cheap trick to iterarte through all transactions that belong to a block
+	// The iterator below is a cheap trick to iterate through all transactions that belong to a block
 	// at height 'height', that is done with the 'start' of the iterator
 	// The 'end' part is where the magic happens: we construct a key that ends in a character with a higher ASCII
 	// value than any other just so we can include all keys "until the end"

--- a/cmd/monogen/testapp/app/app_config.go
+++ b/cmd/monogen/testapp/app/app_config.go
@@ -124,7 +124,7 @@ var (
 				Name: stakingtypes.ModuleName,
 				Config: appconfig.WrapAny(&stakingmodulev1.Module{
 					// NOTE: specifying a prefix is only necessary when using bech32 addresses
-					// If not specfied, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
+					// If not specified, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
 					Bech32PrefixValidator: AccountAddressPrefix + "valoper",
 					Bech32PrefixConsensus: AccountAddressPrefix + "valcons",
 				}),


### PR DESCRIPTION
Corrected `iterarte` to `iterate`
Corrected `specfied` to `specified`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typographical errors in comments related to transaction rollback and staking module configuration for improved clarity. 

- **Documentation**
	- Updated comments for better understanding without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->