### PR TITLE
Enable starting monomer apps in verifier mode

### DIFF
--- a/docs/docs/build/create-an-app-with-monomer.md
+++ b/docs/docs/build/create-an-app-with-monomer.md
@@ -48,10 +48,10 @@ go build -ldflags=-checklinkname=0 -o testappd ./cmd/testappd
 Now that our application is configured, we can start the Monomer application in sequencer mode by running the following command.
 
 ```bash
-./testappd monomer start --minimum-gas-prices 0.01wei --monomer.sequencer-mode --monomer.dev-start --api.enable
+./testappd monomer start --minimum-gas-prices 0.01wei --monomer.sequencer --monomer.dev-start --api.enable
 ````
 
-To run the application in verifier mode, omit the `--monomer.sequencer-mode` flag:
+To run the application in verifier mode, omit the `--monomer.sequencer` flag:
 
 ```bash
 ./testappd monomer start --minimum-gas-prices 0.01wei --monomer.dev-start --api.enable

--- a/docs/docs/build/create-an-app-with-monomer.md
+++ b/docs/docs/build/create-an-app-with-monomer.md
@@ -45,10 +45,16 @@ If using a Go version `>=1.23.0`, run:
 go build -ldflags=-checklinkname=0 -o testappd ./cmd/testappd
 ````
 
-Now that our application is configured, we can start the Monomer application by running the following command.
+Now that our application is configured, we can start the Monomer application in sequencer mode by running the following command.
+
+```bash
+./testappd monomer start --minimum-gas-prices 0.01wei --monomer.sequencer-mode --monomer.dev-start --api.enable
+````
+
+To run the application in verifier mode, omit the `--monomer.sequencer-mode` flag:
 
 ```bash
 ./testappd monomer start --minimum-gas-prices 0.01wei --monomer.dev-start --api.enable
-````
+```
 
 Congratulations! You've successfully integrated Monomer into your Cosmos SDK application.

--- a/docs/docs/build/interact.md
+++ b/docs/docs/build/interact.md
@@ -10,7 +10,7 @@ We will need to have an account on L1 with funds.
 To give yourself funds on the devnet at genesis, run the devnet start command specified in the last tutorial with the `--monomer.dev.l1-user-address` flag:
 
 ```bash
-./testappd monomer start --minimum-gas-prices 0.01wei --monomer.sequencer-mode --monomer.dev-start --api.enable --monomer.dev.l1-user-address "<address>"
+./testappd monomer start --minimum-gas-prices 0.01wei --monomer.sequencer --monomer.dev-start --api.enable --monomer.dev.l1-user-address "<address>"
 ```
 
 ## Configuring L1 and L2 Wallets

--- a/docs/docs/build/interact.md
+++ b/docs/docs/build/interact.md
@@ -10,7 +10,7 @@ We will need to have an account on L1 with funds.
 To give yourself funds on the devnet at genesis, run the devnet start command specified in the last tutorial with the `--monomer.dev.l1-user-address` flag:
 
 ```bash
-./testappd monomer start --minimum-gas-prices 0.01wei --monomer.dev-start --api.enable --monomer.dev.l1-user-address "<address>"
+./testappd monomer start --minimum-gas-prices 0.01wei --monomer.sequencer-mode --monomer.dev-start --api.enable --monomer.dev.l1-user-address "<address>"
 ```
 
 ## Configuring L1 and L2 Wallets

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -71,7 +71,7 @@ func Run(
 		"monomer",
 		"start",
 		"--minimum-gas-prices", "0.001wei",
-		"--monomer.sequencer-mode",
+		"--monomer.sequencer",
 		"--monomer.dev-start",
 	))
 	appCmd.Dir = appDirPath

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -71,6 +71,7 @@ func Run(
 		"monomer",
 		"start",
 		"--minimum-gas-prices", "0.001wei",
+		"--monomer.sequencer-mode",
 		"--monomer.dev-start",
 	))
 	appCmd.Dir = appDirPath

--- a/integrations/integrations.go
+++ b/integrations/integrations.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	flagEngineURL         = "monomer.engine-url"
-	flagSequencerMode     = "monomer.sequencer-mode"
+	flagSequencerMode     = "monomer.sequencer"
 	flagDev               = "monomer.dev-start"
 	flagL1AllocsPath      = "monomer.dev.l1-allocs"
 	flagL1DeploymentsPath = "monomer.dev.l1-deployments"

--- a/integrations/integrations.go
+++ b/integrations/integrations.go
@@ -54,6 +54,7 @@ import (
 
 const (
 	flagEngineURL         = "monomer.engine-url"
+	flagSequencerMode     = "monomer.sequencer-mode"
 	flagDev               = "monomer.dev-start"
 	flagL1AllocsPath      = "monomer.dev.l1-allocs"
 	flagL1DeploymentsPath = "monomer.dev.l1-deployments"
@@ -78,6 +79,7 @@ func AddMonomerCommand(rootCmd *cobra.Command, appCreator servertypes.AppCreator
 		StartCommandHandler: startCommandHandler,
 		AddFlags: func(cmd *cobra.Command) {
 			cmd.Flags().String(flagEngineURL, "ws://127.0.0.1:9000", "url of Monomer's Engine API endpoint")
+			cmd.Flags().Bool(flagSequencerMode, false, "enable sequencer mode for the Monomer node")
 			cmd.Flags().Bool(flagDev, false, "run the OP Stack devnet in-process for testing")
 			cmd.Flags().String(flagL1URL, "ws://127.0.0.1:9001", "")
 			cmd.Flags().String(flagOPNodeURL, "http://127.0.0.1:9002", "")
@@ -302,6 +304,7 @@ func startOPDevnet(
 	if err != nil {
 		return fmt.Errorf("build op config: %v", err)
 	}
+	opConfig.Node.Driver.SequencerEnabled = v.GetBool(flagSequencerMode)
 	if err := opConfig.Run(ctx, env, logger); err != nil {
 		return fmt.Errorf("run op: %v", err)
 	}

--- a/opdevnet/op.go
+++ b/opdevnet/op.go
@@ -144,6 +144,11 @@ func (cfg *OPConfig) Run(ctx context.Context, env *environment.Env, logger log.L
 		return opNode.Stop(context.Background())
 	})
 
+	// Do not start the batcher and proposer if the node is running in verifier mode
+	if !cfg.Node.Driver.SequencerEnabled {
+		return nil
+	}
+
 	// Proposer
 	proposerService, err := proposer.ProposerServiceFromCLIConfig(ctx, "v0.1", cfg.Proposer, newLogger(logger, "proposer"))
 	if err != nil {

--- a/opdevnet/opdevnet_test.go
+++ b/opdevnet/opdevnet_test.go
@@ -177,17 +177,15 @@ func TestOPDevnet(t *testing.T) {
 	require.NoError(t, verifierOpConfig.Run(ctx, env, log.NewLogger(log.NewTerminalHandler(openLogFile(t, env, "op-verifier"), false))))
 
 	// Wait for the verifier node to sync to block 10
-	const waitBlocks = 30
-	for i := 0; i < waitBlocks; i++ {
+	for i := 0; i < 30; i++ {
 		if verifierL2Backend.BlockChain().CurrentHeader().Number.Uint64() >= 10 {
 			// Assert that the verifier and sequencer state roots at block 10 are equal
 			require.Equal(t, verifierL2Backend.BlockChain().GetHeaderByNumber(10).Root, l2Backend.BlockChain().GetHeaderByNumber(10).Root)
-			break
-		} else if i == waitBlocks-1 {
-			t.Fatalf("verifier only synced to block %v", verifierL2Backend.BlockChain().CurrentHeader().Number)
+			return
 		}
 		time.Sleep(time.Second * time.Duration(l1Config.BlockTime))
 	}
+	t.Fatalf("verifier only synced to block %v", verifierL2Backend.BlockChain().CurrentHeader().Number)
 }
 
 // Copied and slightly modified from optimism/op-e2e.


### PR DESCRIPTION
Introduces the `--monomer.sequencer-mode` flag to start the Monomer application in sequencer mode. Otherwise, the Monomer application will be started in verifier mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for creating a Monomer application, clarifying command-line options for running in sequencer and verifier modes.
	- Revised documentation for interacting with Monomer Rollup Devnet to reflect changes in the startup command.
- **New Features**
	- Introduced a new command-line flag to enable sequencer mode for the Monomer node.
	- Enhanced testing capabilities by adding functionality for setting up and running a verifier node alongside the sequencer node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->