### PR TITLE
chore: correct spelling in comments across multiple files

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -110,7 +110,7 @@ func (b *Builder) Build(ctx context.Context, payload *Payload) (*monomer.Block, 
 	if !payload.NoTxPool {
 		for {
 			// TODO there is risk of losing txs if mempool db fails.
-			// we need to fix db consistency in general, so we're just panicing on errors for now.
+			// we need to fix db consistency in general, so we're just panicking on errors for now.
 			length, err := b.mempool.Len()
 			if err != nil {
 				panic(fmt.Errorf("enqueue: %v", err))

--- a/cmd/monogen/testapp/app/app_config.go
+++ b/cmd/monogen/testapp/app/app_config.go
@@ -124,7 +124,7 @@ var (
 				Name: stakingtypes.ModuleName,
 				Config: appconfig.WrapAny(&stakingmodulev1.Module{
 					// NOTE: specifying a prefix is only necessary when using bech32 addresses
-					// If not specfied, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
+					// If not specified, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
 					Bech32PrefixValidator: AccountAddressPrefix + "valoper",
 					Bech32PrefixConsensus: AccountAddressPrefix + "valcons",
 				}),

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -48,7 +48,7 @@ func (e *Env) DeferErr(errMsg string, fn func() error) {
 }
 
 // Close waits for all functions run with Go to finish. Then, it runs all Defer-ed functions.
-// The defered functions are called in reverse order. The Environment must not be used after Close is called.
+// The deferred functions are called in reverse order. The Environment must not be used after Close is called.
 func (e *Env) Close() error {
 	e.wg.Wait()
 	var combinedErr error


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- builder/builder.go: Corrected "panicing" to "panicking"
- cmd/monogen/testapp/app/app_config.go: Fixed "specifed" to "specified" 
- environment/environment.go: Corrected "defered" to "deferred"

These changes are purely cosmetic and fix spelling errors in comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected minor typos in comments to improve clarity and readability. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->